### PR TITLE
List imported authorizations

### DIFF
--- a/app/assets/stylesheets/decidim/direct_verifications/authorizations.scss
+++ b/app/assets/stylesheets/decidim/direct_verifications/authorizations.scss
@@ -1,0 +1,23 @@
+// Copied from "decidim/admin/utils/settings". We better import the file
+
+$black: #1a181d;
+$font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
+$global-weight-normal: normal;
+$light-gray: #eee;
+$medium-gray: #adadad;
+
+$code-color: $black;
+$code-font-family: $font-family-monospace;
+$code-font-weight: $global-weight-normal;
+$code-background: $light-gray;
+$code-border: 1px solid $medium-gray;
+$code-padding: rem-calc(2 5 1);
+
+.code {
+  background: $code-background;
+  color: $code-color;
+  font-family: $code-font-family;
+  font-weight: $code-font-weight;
+  border: $code-border;
+  padding: $code-padding;
+}

--- a/app/controllers/decidim/direct_verifications/verification/admin/authorizations_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/authorizations_controller.rb
@@ -8,7 +8,24 @@ module Decidim
           layout "decidim/admin/users"
 
           def index
-            @authorizations = Decidim::Authorization.where(name: "direct_verifications")
+            @authorizations = collection
+          end
+
+          def destroy
+            if authorization.destroy
+              flash[:notice] = "successfully"
+              redirect_to authorizations_path
+            end
+          end
+
+          private
+
+          def collection
+            Decidim::Authorization.where(name: "direct_verifications")
+          end
+
+          def authorization
+            @authorization ||= collection.find_by(id: params[:id])
           end
         end
       end

--- a/app/controllers/decidim/direct_verifications/verification/admin/authorizations_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/authorizations_controller.rb
@@ -8,6 +8,7 @@ module Decidim
           layout "decidim/admin/users"
 
           def index
+            enforce_permission_to :index, :authorization
             @authorizations = collection
           end
 

--- a/app/controllers/decidim/direct_verifications/verification/admin/authorizations_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/authorizations_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    module Verification
+      module Admin
+        class AuthorizationsController < Decidim::Admin::ApplicationController
+          layout "decidim/admin/users"
+
+          def index
+            @authorizations = Decidim::Authorization.where(name: "direct_verifications")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/direct_verifications/verification/admin/authorizations_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/authorizations_controller.rb
@@ -21,7 +21,7 @@ module Decidim
           private
 
           def collection
-            Decidim::Authorization.where(name: "direct_verifications")
+            Decidim::Authorization.where(name: "direct_verifications").includes(:user)
           end
 
           def authorization

--- a/app/views/decidim/direct_verifications/verification/admin/authorizations/index.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/authorizations/index.html.erb
@@ -4,6 +4,7 @@
   <div class="card-divider">
     <h2 class="card-title">
       <%= t('.title') %>
+      <%= link_to t(".new_import"), direct_verifications_path, class: "button tiny button--title" %>
     </h2>
   </div>
   <div class="card-section">
@@ -15,6 +16,7 @@
             <th><%= t('.metadata') %></th>
             <th><%= t('.user_name') %></th>
             <th><%= t('.created_at') %></th>
+            <th>&nbsp;</th>
           </tr>
         </thead>
         <tbody>
@@ -26,6 +28,10 @@
               </td>
               <td><%= authorization.decidim_user_id %></td>
               <td><%= authorization.created_at %></td>
+
+              <td class="table-list__actions">
+                <%= icon_link_to "circle-x", authorization_path(authorization), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/decidim/direct_verifications/verification/admin/authorizations/index.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/authorizations/index.html.erb
@@ -1,0 +1,35 @@
+<%= stylesheet_link_tag "decidim/direct_verifications/authorizations" %>
+
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t('.title') %>
+    </h2>
+  </div>
+  <div class="card-section">
+    <div class="table-scroll">
+      <table class="table-list">
+        <thead>
+          <tr>
+            <th><%= t('.name') %></th>
+            <th><%= t('.metadata') %></th>
+            <th><%= t('.user_name') %></th>
+            <th><%= t('.created_at') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @authorizations.each do |authorization| %>
+            <tr data-authorization-id="<%= authorization.id %>">
+              <td><%= authorization.name %></td>
+              <td class="metadata">
+                <span class="code"><%= authorization.metadata %></span>
+              </td>
+              <td><%= authorization.decidim_user_id %></td>
+              <td><%= authorization.created_at %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/direct_verifications/verification/admin/authorizations/index.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/authorizations/index.html.erb
@@ -26,7 +26,7 @@
               <td class="metadata">
                 <span class="code"><%= authorization.metadata %></span>
               </td>
-              <td><%= authorization.decidim_user_id %></td>
+              <td><%= authorization.user.name %></td>
               <td><%= authorization.created_at %></td>
 
               <td class="table-list__actions">

--- a/app/views/decidim/direct_verifications/verification/admin/authorizations/index.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/authorizations/index.html.erb
@@ -4,6 +4,7 @@
   <div class="card-divider">
     <h2 class="card-title">
       <%= t('.title') %>
+      <%= link_to t("admin.index.stats", scope: 'decidim.direct_verifications.verification'), stats_path, class: "button tiny button--title" %>
       <%= link_to t(".new_import"), direct_verifications_path, class: "button tiny button--title" %>
     </h2>
   </div>

--- a/app/views/decidim/direct_verifications/verification/admin/direct_verifications/index.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/direct_verifications/index.html.erb
@@ -3,6 +3,7 @@
     <h2 class="card-title">
       <%= t('admin.index.title', scope: 'decidim.direct_verifications.verification') %>
       <%= link_to t("admin.index.stats", scope: 'decidim.direct_verifications.verification'), stats_path, class: "button tiny button--title" %>
+      <%= link_to t("admin.index.authorizations", scope: "decidim.direct_verifications.verification"), authorizations_path, class: "button tiny button--title" %>
     </h2>
   </div>
   <div class="card-section">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,13 @@ en:
     direct_verifications:
       verification:
         admin:
+          authorizations:
+            index:
+              created_at: Created at
+              metadata: Metadata
+              name: Name
+              title: Authorizations
+              user_name: User name
           direct_verifications:
             create:
               authorized: "%{authorized} users have been successfully verified using
@@ -35,6 +42,7 @@ en:
               need to have explicit consent from your users in order to register them.
               Otherwise you will be infringing the GDPR regulation in EU countries.
           index:
+            authorizations: Imported emails
             stats: User stats
             title: Register and authorize users
           new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
               name: Name
               title: Authorizations
               user_name: User name
+              new_import: New import
           direct_verifications:
             create:
               authorized: "%{authorized} users have been successfully verified using
@@ -42,7 +43,7 @@ en:
               need to have explicit consent from your users in order to register them.
               Otherwise you will be infringing the GDPR regulation in EU countries.
           index:
-            authorizations: Imported emails
+            authorizations: Authorized users
             stats: User stats
             title: Register and authorize users
           new:

--- a/lib/decidim/direct_verifications/tests/factories.rb
+++ b/lib/decidim/direct_verifications/tests/factories.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "decidim/core/test/factories"
+
+FactoryBot.modify do
+  factory :authorization do
+    trait :direct_verification do
+      name { "direct_verifications" }
+    end
+  end
+end

--- a/lib/decidim/direct_verifications/verification/admin_engine.rb
+++ b/lib/decidim/direct_verifications/verification/admin_engine.rb
@@ -10,6 +10,7 @@ module Decidim
         routes do
           resources :direct_verifications, only: [:index, :create, :stats]
           resources :stats, only: [:index]
+          resources :authorizations, only: [:index]
 
           root to: "direct_verifications#index"
         end

--- a/lib/decidim/direct_verifications/verification/admin_engine.rb
+++ b/lib/decidim/direct_verifications/verification/admin_engine.rb
@@ -10,7 +10,7 @@ module Decidim
         routes do
           resources :direct_verifications, only: [:index, :create, :stats]
           resources :stats, only: [:index]
-          resources :authorizations, only: [:index]
+          resources :authorizations, only: [:index, :destroy]
 
           root to: "direct_verifications#index"
         end

--- a/spec/controllers/decidim/direct_verifications/verification/admin/authorizations_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/authorizations_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::DirectVerifications::Verification::Admin
+  describe AuthorizationsController, type: :controller do
+    routes { Decidim::DirectVerifications::Verification::AdminEngine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      sign_in user
+    end
+
+    describe "#index" do
+      it "renders the decidim/admin/users layout" do
+        get :index
+        expect(response).to render_template("layouts/decidim/admin/users")
+      end
+    end
+  end
+end

--- a/spec/controllers/decidim/direct_verifications/verification/admin/authorizations_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/authorizations_controller_spec.rb
@@ -15,6 +15,12 @@ module Decidim::DirectVerifications::Verification::Admin
     end
 
     describe "#index" do
+      it "authorizes the action" do
+        expect(controller).to receive(:allowed_to?).with(:index, :authorization, {})
+
+        get :index
+      end
+
       it "renders the decidim/admin/users layout" do
         get :index
         expect(response).to render_template("layouts/decidim/admin/users")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "decidim/core/test/factories"
+require "decidim/direct_verifications/tests/factories"

--- a/spec/system/decidim/direct_verifications/admin/admin_manages_imported_authorizations_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_manages_imported_authorizations_spec.rb
@@ -31,7 +31,7 @@ describe "Admin manages imported authorizations", type: :system do
       within "tr[data-authorization-id=\"#{authorization.id}\"]" do
         expect(page).to have_content(authorization.name)
         expect(page).to have_content(authorization.metadata)
-        expect(page).to have_content(authorization.decidim_user_id)
+        expect(page).to have_content(authorization.user.name)
         expect(page).to have_content(authorization.created_at)
       end
 

--- a/spec/system/decidim/direct_verifications/admin/admin_manages_imported_authorizations_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_manages_imported_authorizations_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages imported authorizations", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  let!(:authorization) { create(:authorization, :direct_verification) }
+  let!(:non_direct_authorization) { create(:authorization) }
+
+  let(:scope) { "decidim.direct_verifications.verification.admin" }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  it "lists authorizations imported through direct_verifications" do
+    visit decidim_admin_direct_verifications.direct_verifications_path
+    click_link I18n.t("index.authorizations", scope: scope)
+
+    expect(page).to have_current_path(decidim_admin_direct_verifications.authorizations_path)
+
+    within "table thead" do
+      expect(page).to have_content(I18n.t("authorizations.index.name", scope: scope).upcase)
+      expect(page).to have_content(I18n.t("authorizations.index.metadata", scope: scope).upcase)
+      expect(page).to have_content(I18n.t("authorizations.index.user_name", scope: scope).upcase)
+      expect(page).to have_content(I18n.t("authorizations.index.created_at", scope: scope).upcase)
+    end
+
+    within "tr[data-authorization-id=\"#{authorization.id}\"]" do
+      expect(page).to have_content(authorization.name)
+      expect(page).to have_content(authorization.metadata)
+      expect(page).to have_content(authorization.decidim_user_id)
+      expect(page).to have_content(authorization.created_at)
+    end
+
+    expect(page).not_to have_content(non_direct_authorization.name)
+  end
+end

--- a/spec/system/decidim/direct_verifications/admin/admin_manages_imported_authorizations_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_manages_imported_authorizations_spec.rb
@@ -14,28 +14,39 @@ describe "Admin manages imported authorizations", type: :system do
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
-  end
 
-  it "lists authorizations imported through direct_verifications" do
     visit decidim_admin_direct_verifications.direct_verifications_path
     click_link I18n.t("index.authorizations", scope: scope)
+  end
 
-    expect(page).to have_current_path(decidim_admin_direct_verifications.authorizations_path)
+  context "when listing authorizations" do
+    it "lists authorizations imported through direct_verifications" do
+      within "table thead" do
+        expect(page).to have_content(I18n.t("authorizations.index.name", scope: scope).upcase)
+        expect(page).to have_content(I18n.t("authorizations.index.metadata", scope: scope).upcase)
+        expect(page).to have_content(I18n.t("authorizations.index.user_name", scope: scope).upcase)
+        expect(page).to have_content(I18n.t("authorizations.index.created_at", scope: scope).upcase)
+      end
 
-    within "table thead" do
-      expect(page).to have_content(I18n.t("authorizations.index.name", scope: scope).upcase)
-      expect(page).to have_content(I18n.t("authorizations.index.metadata", scope: scope).upcase)
-      expect(page).to have_content(I18n.t("authorizations.index.user_name", scope: scope).upcase)
-      expect(page).to have_content(I18n.t("authorizations.index.created_at", scope: scope).upcase)
+      within "tr[data-authorization-id=\"#{authorization.id}\"]" do
+        expect(page).to have_content(authorization.name)
+        expect(page).to have_content(authorization.metadata)
+        expect(page).to have_content(authorization.decidim_user_id)
+        expect(page).to have_content(authorization.created_at)
+      end
+
+      expect(page).not_to have_content(non_direct_authorization.name)
     end
+  end
 
-    within "tr[data-authorization-id=\"#{authorization.id}\"]" do
-      expect(page).to have_content(authorization.name)
-      expect(page).to have_content(authorization.metadata)
-      expect(page).to have_content(authorization.decidim_user_id)
-      expect(page).to have_content(authorization.created_at)
+  context "when destroying an authorization" do
+    it "destroys the authorizations" do
+      within "tr[data-authorization-id=\"#{authorization.id}\"]" do
+        accept_confirm { click_link "Delete" }
+      end
+
+      expect(page).not_to have_content("tr[data-authorization-id=\"#{authorization.id}\"]")
+      expect(page).to have_admin_callout("successfully")
     end
-
-    expect(page).not_to have_content(non_direct_authorization.name)
   end
 end

--- a/spec/system/decidim/direct_verifications/admin/admin_manages_imported_authorizations_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_manages_imported_authorizations_spec.rb
@@ -37,6 +37,11 @@ describe "Admin manages imported authorizations", type: :system do
 
       expect(page).not_to have_content(non_direct_authorization.name)
     end
+
+    it "lets users navigate to stats and new import" do
+      expect(page).to have_link(t("decidim.direct_verifications.verification.admin.index.stats"))
+      expect(page).to have_link(t("decidim.direct_verifications.verification.admin.authorizations.index.new_import"))
+    end
   end
 
   context "when destroying an authorization" do


### PR DESCRIPTION
## What? Why?

Adds a new page to list the imported authorizations. This lets users know whether the authorizations they just imported are correct.

Then, from that same page, we enable admins to remove individual authorizations. That's slightly easier to manage than the existing `Revoke authorization from users` radio button. Updates, however, still require you to remove the authorization and importing it again.

## :camera_flash: 

![Peek 2020-10-23 12-47](https://user-images.githubusercontent.com/762088/96995088-ee42d100-152d-11eb-8b12-84b559121624.gif)
