### PR TITLE
Fix host app not finding asset

### DIFF
--- a/app/assets/config/direct_verifications_admin_manifest.css
+++ b/app/assets/config/direct_verifications_admin_manifest.css
@@ -1,0 +1,3 @@
+/*
+ *= link decidim/direct_verifications/authorizations.css
+ */

--- a/app/assets/stylesheets/decidim/direct_verifications/authorizations.scss
+++ b/app/assets/stylesheets/decidim/direct_verifications/authorizations.scss
@@ -1,10 +1,4 @@
-// Copied from "decidim/admin/utils/settings". We better import the file
-
-$black: #1a181d;
-$font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
-$global-weight-normal: normal;
-$light-gray: #eee;
-$medium-gray: #adadad;
+@import "decidim/admin/utils/settings";
 
 $code-color: $black;
 $code-font-family: $font-family-monospace;

--- a/lib/decidim/direct_verifications/verification/admin_engine.rb
+++ b/lib/decidim/direct_verifications/verification/admin_engine.rb
@@ -16,7 +16,10 @@ module Decidim
         end
 
         initializer "decidim_direct_verifications.admin_assets" do |app|
-          app.config.assets.precompile += %w(direct_verifications_admin_manifest.js)
+          app.config.assets.precompile += %w(
+            direct_verifications_admin_manifest.js
+            direct_verifications_admin_manifest.css
+          )
         end
       end
     end


### PR DESCRIPTION
This fixes the error:

```
ActionView::Template::Error (The asset "decidim/direct_verifications/authorizations.css" is not present in the asset pipeline.)
<%= stylesheet_link_tag "decidim/direct_verifications/authorizations" %>
```

caused by https://github.com/Platoniq/decidim-verifications-direct_verifications/pull/4