### PR TITLE
Fix form object not responding to #invalid?

### DIFF
--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -33,9 +33,6 @@ module Decidim
                 add_processed :registered, email
                 log_action find_user(email)
               end
-              on(:invalid) do
-                add_error :registered, email
-              end
             end
           rescue StandardError
             add_error :registered, email


### PR DESCRIPTION
I opened this to show how removing those lines the tests still pass.

This is because the form, being an OpenStruct, it doesn't implement the `#invalid?` method `InviteUser` relies on. This makes skip the early return and normally go on with the invitation, however, the DB complains about the violation of the null constraint (the email is empty) and raises. This is then caught by the `UserProcessor`.

The question is @microstudi how do you prefer to proceed? We captured this with the `rescue` but I wonder if there might be other scenarios that don't raise an exception and in which the invitation might be created where it shouldn't. That'd mean implementing a proper `Form` class with `#invalid?`.