### PR TITLE
Process registration individually

### DIFF
--- a/app/forms/decidim/direct_verifications/registration_form.rb
+++ b/app/forms/decidim/direct_verifications/registration_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class RegistrationForm < OpenStruct
+    end
+  end
+end

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -23,7 +23,7 @@ module Decidim
                  data
                end
 
-        form = register_form(email, name)
+        form = build_form(email, name)
         begin
           InviteUser.call(form) do
             on(:ok) do
@@ -48,13 +48,15 @@ module Decidim
         User.find_by(email: email, decidim_organization_id: organization.id)
       end
 
-      def register_form(email, name)
-        OpenStruct.new(name: name.presence || fallback_name(email),
-                       email: email.downcase,
-                       organization: organization,
-                       admin: false,
-                       invited_by: current_user,
-                       invitation_instructions: "direct_invite")
+      def build_form(email, name)
+        RegistrationForm.new(
+          name: name.presence || fallback_name(email),
+          email: email.downcase,
+          organization: organization,
+          admin: false,
+          invited_by: current_user,
+          invitation_instructions: "direct_invite"
+        )
       end
 
       def fallback_name(email)

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -12,8 +12,6 @@ module Decidim
         @instrumenter = instrumenter
       end
 
-      delegate :add_error, :add_processed, :log_action, to: :instrumenter
-
       def call
         return if find_user
 
@@ -22,15 +20,15 @@ module Decidim
         begin
           InviteUser.call(form) do
             on(:ok) do
-              add_processed :registered, email
-              log_action find_user
+              instrumenter.add_processed :registered, email
+              instrumenter.log_action find_user
             end
             on(:invalid) do
-              add_error :registered, email
+              instrumenter.add_error :registered, email
             end
           end
         rescue StandardError => e
-          add_error :registered, email
+          instrumenter.add_error :registered, email
           raise e if Rails.env.test? || Rails.env.development?
         end
       end

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -20,15 +20,14 @@ module Decidim
         begin
           InviteUser.call(form) do
             on(:ok) do
-              instrumenter.add_processed :registered, email
-              instrumenter.log_action find_user
+              instrumenter.track(:registered, email, find_user)
             end
             on(:invalid) do
-              instrumenter.add_error :registered, email
+              instrumenter.track(:registered, email)
             end
           end
         rescue StandardError => e
-          instrumenter.add_error :registered, email
+          instrumenter.track(:registered, email)
           raise e if Rails.env.test? || Rails.env.development?
         end
       end

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -15,14 +15,15 @@ module Decidim
       delegate :add_error, :add_processed, :log_action, to: :instrumenter
 
       def call
-        return if find_user(email)
+        return if find_user
 
-        form = build_form(email, name)
+        form = build_form
+
         begin
           InviteUser.call(form) do
             on(:ok) do
               add_processed :registered, email
-              log_action find_user(email)
+              log_action find_user
             end
             on(:invalid) do
               add_error :registered, email
@@ -38,13 +39,13 @@ module Decidim
 
       attr_reader :email, :name, :organization, :current_user, :instrumenter
 
-      def find_user(email)
+      def find_user
         User.find_by(email: email, decidim_organization_id: organization.id)
       end
 
-      def build_form(email, name)
+      def build_form
         RegistrationForm.new(
-          name: name.presence || fallback_name(email),
+          name: name.presence || fallback_name,
           email: email.downcase,
           organization: organization,
           admin: false,
@@ -53,7 +54,7 @@ module Decidim
         )
       end
 
-      def fallback_name(email)
+      def fallback_name
         email.split("@").first
       end
     end

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -3,7 +3,6 @@
 module Decidim
   module DirectVerifications
     class RegisterUser
-
       def initialize(email, name, organization, current_user, instrumenter)
         @email = email
         @name = name

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -4,9 +4,9 @@ module Decidim
   module DirectVerifications
     class RegisterUser
 
-      def initialize(email, data, organization, current_user, instrumenter)
+      def initialize(email, name, organization, current_user, instrumenter)
         @email = email
-        @data = data
+        @name = name
         @organization = organization
         @current_user = current_user
         @instrumenter = instrumenter
@@ -16,12 +16,6 @@ module Decidim
 
       def call
         return if find_user(email)
-
-        name = if data.is_a?(Hash)
-                 data[:name]
-               else
-                 data
-               end
 
         form = build_form(email, name)
         begin
@@ -42,7 +36,7 @@ module Decidim
 
       private
 
-      attr_reader :email, :data, :organization, :current_user, :instrumenter
+      attr_reader :email, :name, :organization, :current_user, :instrumenter
 
       def find_user(email)
         User.find_by(email: email, decidim_organization_id: organization.id)

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class RegisterUser
+
+      def initialize(email, data, organization, current_user, instrumenter)
+        @email = email
+        @data = data
+        @organization = organization
+        @current_user = current_user
+        @instrumenter = instrumenter
+      end
+
+      delegate :add_error, :add_processed, :log_action, to: :instrumenter
+
+      def call
+        return if find_user(email)
+
+        name = if data.is_a?(Hash)
+                 data[:name]
+               else
+                 data
+               end
+
+        form = register_form(email, name)
+        begin
+          InviteUser.call(form) do
+            on(:ok) do
+              add_processed :registered, email
+              log_action find_user(email)
+            end
+            on(:invalid) do
+              add_error :registered, email
+            end
+          end
+        rescue StandardError => e
+          add_error :registered, email
+          raise e if Rails.env.test? || Rails.env.development?
+        end
+      end
+
+      private
+
+      attr_reader :email, :data, :organization, :current_user, :instrumenter
+
+      def find_user(email)
+        User.find_by(email: email, decidim_organization_id: organization.id)
+      end
+
+      def register_form(email, name)
+        OpenStruct.new(name: name.presence || fallback_name(email),
+                       email: email.downcase,
+                       organization: organization,
+                       admin: false,
+                       invited_by: current_user,
+                       invitation_instructions: "direct_invite")
+      end
+
+      def fallback_name(email)
+        email.split("@").first
+      end
+    end
+  end
+end

--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -20,7 +20,12 @@ module Decidim
 
       def register_users
         emails.each do |email, data|
-          RegisterUser.new(email, data, organization, current_user, self).call
+          name = if data.is_a?(Hash)
+                   data[:name]
+                 else
+                   data
+                 end
+          RegisterUser.new(email, name, organization, current_user, self).call
         end
       end
 

--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/direct_verifications/register_user"
+
 module Decidim
   module DirectVerifications
     class UserProcessor
@@ -18,28 +20,7 @@ module Decidim
 
       def register_users
         emails.each do |email, data|
-          next if find_user(email)
-
-          name = if data.is_a?(Hash)
-                   data[:name]
-                 else
-                   data
-                 end
-
-          form = register_form(email, name)
-          begin
-            InviteUser.call(form) do
-              on(:ok) do
-                add_processed :registered, email
-                log_action find_user(email)
-              end
-              on(:invalid) do
-                add_error :registered, email
-              end
-            end
-          rescue StandardError
-            add_error :registered, email
-          end
+          RegisterUser.new(email, data, organization, current_user, self).call
         end
       end
 
@@ -85,42 +66,12 @@ module Decidim
         end
       end
 
-      private
-
-      def find_user(email)
-        User.find_by(email: email, decidim_organization_id: @organization.id)
-      end
-
-      def register_form(email, name)
-        OpenStruct.new(name: name.presence || fallback_name(email),
-                       email: email.downcase,
-                       organization: organization,
-                       admin: false,
-                       invited_by: current_user,
-                       invitation_instructions: "direct_invite")
-      end
-
-      def fallback_name(email)
-        email.split("@").first
-      end
-
-      def authorization(user)
-        Authorization.find_or_initialize_by(
-          user: user,
-          name: authorization_handler
-        )
-      end
-
-      def authorize_form(user)
-        Verification::DirectVerificationsForm.new(email: user.email, name: user.name)
+      def add_error(type, email)
+        @errors[type] << email unless @errors[type].include? email
       end
 
       def add_processed(type, email)
         @processed[type] << email unless @processed[type].include? email
-      end
-
-      def add_error(type, email)
-        @errors[type] << email unless @errors[type].include? email
       end
 
       def log_action(user)
@@ -133,6 +84,23 @@ module Decidim
             invited_user_id: user.id
           }
         )
+      end
+
+      private
+
+      def find_user(email)
+        User.find_by(email: email, decidim_organization_id: @organization.id)
+      end
+
+      def authorization(user)
+        Authorization.find_or_initialize_by(
+          user: user,
+          name: authorization_handler
+        )
+      end
+
+      def authorize_form(user)
+        Verification::DirectVerificationsForm.new(email: user.email, name: user.name)
       end
     end
   end

--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -71,6 +71,17 @@ module Decidim
         end
       end
 
+      def track(event, email, user = nil)
+        if user
+          add_processed event, email
+          log_action user
+        else
+          add_error event, email
+        end
+      end
+
+      private
+
       def add_error(type, email)
         @errors[type] << email unless @errors[type].include? email
       end
@@ -90,8 +101,6 @@ module Decidim
           }
         )
       end
-
-      private
 
       def find_user(email)
         User.find_by(email: email, decidim_organization_id: @organization.id)

--- a/spec/lib/decidim/direct_verifications/register_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/register_user_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe RegisterUser do
+      subject { described_class.new(email, name, organization, user, instrumenter) }
+
+      let(:user) { build(:user) }
+      let(:organization) { build(:organization) }
+      let(:instrumenter) do
+        instance_double(UserProcessor, add_processed: true, add_error: true, log_action: true)
+      end
+
+      let(:email) { "em@il.com" }
+      let(:name) { "Joni" }
+
+      describe "#call" do
+        context "when registering valid users" do
+          let(:email) { "em@il.com" }
+          let(:name) { "Joni" }
+
+          it "tracks the operation" do
+            subject.call
+
+            expect(instrumenter).to have_received(:add_processed).with(:registered, email)
+            expect(instrumenter).to have_received(:log_action).with(kind_of(Decidim::User))
+            expect(instrumenter).not_to have_received(:add_error)
+          end
+
+          it "invites the user" do
+            expect(InviteUser).to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when registering users that already exist" do
+          let(:email) { "em@il.com" }
+          let(:name) { "Joni" }
+
+          let!(:user) { create(:user, email: email, organization: organization) }
+
+          it "doesn't track the operation" do
+            subject.call
+
+            expect(instrumenter).not_to have_received(:add_processed)
+            expect(instrumenter).not_to have_received(:add_error)
+          end
+
+          it "does not invite the user" do
+            expect(InviteUser).not_to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when registering users without name" do
+          let(:email) { "em@il.com" }
+          let(:name) { nil }
+
+          it "tracks the operation" do
+            subject.call
+
+            expect(instrumenter).to have_received(:add_processed)
+            expect(instrumenter).not_to have_received(:add_error)
+          end
+
+          it "infers the name from the email" do
+            subject.call
+            expect(Decidim::User.last.name).to eq("em")
+          end
+
+          it "invites the user" do
+            expect(InviteUser).to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when registering invalid users" do
+          let(:email) { "" }
+          let(:name) { "" }
+
+          it "tracks the operation" do
+            expect { subject.call }.to raise_error(ActiveRecord::NotNullViolation)
+            expect(instrumenter).to have_received(:add_error).with(:registered, email)
+          end
+
+          it "tries to invite the user" do
+            expect(InviteUser).to receive(:call)
+            subject.call
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/register_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/register_user_spec.rb
@@ -9,9 +9,7 @@ module Decidim
 
       let(:user) { build(:user) }
       let(:organization) { build(:organization) }
-      let(:instrumenter) do
-        instance_double(UserProcessor, add_processed: true, add_error: true, log_action: true)
-      end
+      let(:instrumenter) { instance_double(UserProcessor, track: true) }
 
       let(:email) { "em@il.com" }
       let(:name) { "Joni" }
@@ -24,9 +22,7 @@ module Decidim
           it "tracks the operation" do
             subject.call
 
-            expect(instrumenter).to have_received(:add_processed).with(:registered, email)
-            expect(instrumenter).to have_received(:log_action).with(kind_of(Decidim::User))
-            expect(instrumenter).not_to have_received(:add_error)
+            expect(instrumenter).to have_received(:track).with(:registered, email, kind_of(Decidim::User))
           end
 
           it "invites the user" do
@@ -43,9 +39,7 @@ module Decidim
 
           it "doesn't track the operation" do
             subject.call
-
-            expect(instrumenter).not_to have_received(:add_processed)
-            expect(instrumenter).not_to have_received(:add_error)
+            expect(instrumenter).not_to have_received(:track)
           end
 
           it "does not invite the user" do
@@ -60,9 +54,7 @@ module Decidim
 
           it "tracks the operation" do
             subject.call
-
-            expect(instrumenter).to have_received(:add_processed)
-            expect(instrumenter).not_to have_received(:add_error)
+            expect(instrumenter).to have_received(:track).with(:registered, email, kind_of(Decidim::User))
           end
 
           it "infers the name from the email" do
@@ -82,7 +74,7 @@ module Decidim
 
           it "tracks the operation" do
             expect { subject.call }.to raise_error(ActiveRecord::NotNullViolation)
-            expect(instrumenter).to have_received(:add_error).with(:registered, email)
+            expect(instrumenter).to have_received(:track).with(:registered, email)
           end
 
           it "tries to invite the user" do

--- a/spec/lib/decidim/direct_verifications/user_processor_spec.rb
+++ b/spec/lib/decidim/direct_verifications/user_processor_spec.rb
@@ -54,75 +54,29 @@ module Decidim
         end
       end
 
-      context "when registering valid users" do
-        before do
-          subject.emails = ["em@il.com", "em@il.com", "em@il.net"]
-          subject.register_users
+      describe "#register_users" do
+        context "when registering valid users" do
+          before do
+            subject.emails = ["em@il.com", "em@il.com", "em@il.net"]
+            subject.register_users
+          end
+
+          it "has no errors" do
+            expect(subject.processed[:registered].count).to eq(2)
+            expect(subject.errors[:registered].count).to eq(0)
+          end
         end
 
-        it "has no errors" do
-          expect(subject.processed[:registered].count).to eq(2)
-          expect(subject.errors[:registered].count).to eq(0)
-        end
-      end
+        context "when registering valid users with metadata" do
+          before do
+            subject.emails = { "em@il.com" => { name: "Brandy", type: "producer" } }
+            subject.register_users
+          end
 
-      context "when registering users that already exist" do
-        before do
-          create(:user, email: "em@il.com", organization: organization)
-          subject.emails = ["em@il.com"]
-        end
-
-        it "registers none" do
-          subject.register_users
-
-          expect(subject.processed[:registered].count).to eq(0)
-          expect(subject.errors[:registered].count).to eq(0)
-        end
-
-        it "skips all processing" do
-          expect(InviteUser).not_to receive(:call)
-          subject.register_users
-        end
-      end
-
-      context "when registering valid users with metadata" do
-        before do
-          subject.emails = { "em@il.com" => { name: "Brandy", type: "producer" } }
-          subject.register_users
-        end
-
-        it "has no errors" do
-          expect(subject.processed[:registered].count).to eq(1)
-          expect(subject.errors[:registered].count).to eq(0)
-        end
-      end
-
-      context "when registering users without name" do
-        before do
-          subject.emails = { "em@il.com" => { type: "producer" } }
-          subject.register_users
-        end
-
-        it "has no errors" do
-          expect(subject.processed[:registered].count).to eq(1)
-          expect(subject.errors[:registered].count).to eq(0)
-        end
-
-        it "infers the name from the email" do
-          expect(Decidim::User.find_by(email: "em@il.com").name).to eq("em")
-        end
-      end
-
-      context "when registering invalid users" do
-        before do
-          subject.emails = ["em@il.org", ""]
-        end
-
-        it "has errors" do
-          expect { subject.register_users }.to raise_error(ActiveRecord::NotNullViolation)
-
-          expect(subject.processed[:registered].count).to eq(1)
-          expect(subject.errors[:registered].count).to eq(1)
+          it "has no errors" do
+            expect(subject.processed[:registered].count).to eq(1)
+            expect(subject.errors[:registered].count).to eq(0)
+          end
         end
       end
 


### PR DESCRIPTION
This is the very first step to implement #3. I plan to open two more PRs like this one to the same with the authorization and revocation operations. Then, we'll be able to process these async but without any behavior change, I promise :joy: 