### PR TITLE
Process authorization individually

### DIFF
--- a/lib/decidim/direct_verifications/authorize_user.rb
+++ b/lib/decidim/direct_verifications/authorize_user.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class AuthorizeUser
+      def initialize(email, data, session, organization, instrumenter)
+        @email = email
+        @data = data
+        @session = session
+        @organization = organization
+        @instrumenter = instrumenter
+      end
+
+      def call
+        u = find_user(email)
+
+        if u
+          auth = authorization(u)
+          auth.metadata = data
+
+          return unless !auth.granted? || auth.expired?
+
+          Verification::ConfirmUserAuthorization.call(auth, authorize_form(u), session) do
+            on(:ok) do
+              instrumenter.add_processed :authorized, email
+            end
+            on(:invalid) do
+              instrumenter.add_error :authorized, email
+            end
+          end
+        else
+          instrumenter.add_error :authorized, email
+        end
+      end
+
+      private
+
+      attr_reader :email, :data, :session, :organization, :instrumenter
+
+      def find_user(email)
+        User.find_by(email: email, decidim_organization_id: organization.id)
+      end
+
+      def authorization(user)
+        Authorization.find_or_initialize_by(
+          user: user,
+          name: :direct_verifications
+        )
+      end
+
+      def authorize_form(user)
+        Verification::DirectVerificationsForm.new(email: user.email, name: user.name)
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe AuthorizeUser do
+      subject { described_class.new(email, data, session, organization, instrumenter) }
+
+      describe "#call" do
+        context "when authorizing confirmed users" do
+          let(:organization) { build(:organization) }
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+          let(:session) { {} }
+          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+
+          context "when passing the user name" do
+            let(:data) { user.name }
+
+            it "tracks the operation" do
+              subject.call
+
+              expect(instrumenter).to have_received(:add_processed).with(:authorized, email)
+              expect(instrumenter).not_to have_received(:add_error)
+            end
+
+            it "authorizes the user" do
+              expect(Verification::ConfirmUserAuthorization).to receive(:call)
+              subject.call
+            end
+          end
+
+          context "when passing user data" do
+            let(:data) { { name: user.name, type: "consumer" } }
+
+            it "stores it as authorization metadata" do
+              subject.call
+              expect(Authorization.last.metadata).to eq("name" => user.name, "type" => "consumer")
+            end
+
+            it "authorizes the user" do
+              expect(Verification::ConfirmUserAuthorization).to receive(:call)
+              subject.call
+            end
+          end
+
+          context "when the user fails to be authorized" do
+            let(:form) { instance_double(Verification::DirectVerificationsForm, valid?: false) }
+            let(:data) { user.name }
+
+            before do
+              allow(Verification::DirectVerificationsForm)
+                .to receive(:new).with(email: user.email, name: user.name) { form }
+            end
+
+            it "tracks the error" do
+              subject.call
+              expect(instrumenter).to have_received(:add_error).with(:authorized, email)
+            end
+          end
+        end
+
+        context "when authorizing unregistered users" do
+          let(:organization) { build(:organization) }
+          let(:user) { nil }
+          let(:email) { "em@mail.com" }
+          let(:data) { "Andy" }
+          let(:session) { {} }
+          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+
+          it "tracks an error" do
+            subject.call
+
+            expect(instrumenter).not_to have_received(:add_processed)
+            expect(instrumenter).to have_received(:add_error).with(:authorized, email)
+          end
+
+          it "does not authorize the user" do
+            expect(Verification::ConfirmUserAuthorization).not_to receive(:call)
+            subject.call
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/user_processor_spec.rb
+++ b/spec/lib/decidim/direct_verifications/user_processor_spec.rb
@@ -34,22 +34,24 @@ module Decidim
 
       context "when add processed" do
         it "has unique emails per type" do
-          subject.send(:add_processed, :registered, "em@il.com")
-          subject.send(:add_processed, :registered, "em@il.com")
+          subject.add_processed(:registered, "em@il.com")
+          subject.add_processed(:registered, "em@il.com")
           expect(subject.processed[:registered].count).to eq(1)
-          subject.send(:add_processed, :authorized, "em@il.com")
-          subject.send(:add_processed, :authorized, "em@il.com")
+
+          subject.add_processed(:authorized, "em@il.com")
+          subject.add_processed(:authorized, "em@il.com")
           expect(subject.processed[:authorized].count).to eq(1)
         end
       end
 
       context "when add errors" do
         it "has unique emails per type" do
-          subject.send(:add_error, :registered, "em@il.com")
-          subject.send(:add_error, :registered, "em@il.com")
+          subject.add_error(:registered, "em@il.com")
+          subject.add_error(:registered, "em@il.com")
           expect(subject.errors[:registered].count).to eq(1)
-          subject.send(:add_error, :authorized, "em@il.com")
-          subject.send(:add_error, :authorized, "em@il.com")
+
+          subject.add_error(:authorized, "em@il.com")
+          subject.add_error(:authorized, "em@il.com")
           expect(subject.errors[:authorized].count).to eq(1)
         end
       end


### PR DESCRIPTION
Like in #21, by enabling the authorization of a single user from a single class we can later perform the action however we want: async, in batches, etc. This class doesn't care how and who calls it.