### PR TITLE
Decouple instrumentation from user processor

### DIFF
--- a/lib/decidim/direct_verifications/authorize_user.rb
+++ b/lib/decidim/direct_verifications/authorize_user.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class AuthorizeUser
+      def initialize(email, data, session, organization, instrumenter)
+        @email = email
+        @data = data
+        @session = session
+        @organization = organization
+        @instrumenter = instrumenter
+      end
+
+      def call
+        u = find_user(email)
+
+        if u
+          auth = authorization(u)
+          auth.metadata = data
+
+          return unless !auth.granted? || auth.expired?
+
+          Verification::ConfirmUserAuthorization.call(auth, authorize_form(u), session) do
+            on(:ok) do
+              instrumenter.add_processed :authorized, email
+            end
+            on(:invalid) do
+              instrumenter.add_error :authorized, email
+            end
+          end
+        else
+          instrumenter.add_error :authorized, email
+        end
+      end
+
+      private
+
+      attr_reader :email, :data, :session, :organization, :instrumenter
+
+      def find_user(email)
+        User.find_by(email: email, decidim_organization_id: organization.id)
+      end
+
+      def authorization(user)
+        Authorization.find_or_initialize_by(
+          user: user,
+          name: :direct_verifications
+        )
+      end
+
+      def authorize_form(user)
+        Verification::DirectVerificationsForm.new(email: user.email, name: user.name)
+      end
+    end
+  end
+end

--- a/lib/decidim/direct_verifications/authorize_user.rb
+++ b/lib/decidim/direct_verifications/authorize_user.rb
@@ -12,15 +12,15 @@ module Decidim
       end
 
       def call
-        u = find_user(email)
+        user = find_user
 
-        if u
-          auth = authorization(u)
+        if user
+          auth = authorization(user)
           auth.metadata = data
 
           return unless !auth.granted? || auth.expired?
 
-          Verification::ConfirmUserAuthorization.call(auth, authorize_form(u), session) do
+          Verification::ConfirmUserAuthorization.call(auth, authorize_form(user), session) do
             on(:ok) do
               instrumenter.add_processed :authorized, email
             end
@@ -37,7 +37,7 @@ module Decidim
 
       attr_reader :email, :data, :session, :organization, :instrumenter
 
-      def find_user(email)
+      def find_user
         User.find_by(email: email, decidim_organization_id: organization.id)
       end
 

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class Instrumenter
+      attr_reader :processed, :errors
+
+      def initialize(current_user)
+        @current_user = current_user
+        @errors = { registered: [], authorized: [], revoked: [] }
+        @processed = { registered: [], authorized: [], revoked: [] }
+      end
+
+      def track(event, email, user = nil)
+        if user
+          add_processed event, email
+          log_action user
+        else
+          add_error event, email
+        end
+      end
+
+      def add_error(type, email)
+        @errors[type] << email unless @errors[type].include? email
+      end
+
+      def add_processed(type, email)
+        @processed[type] << email unless @processed[type].include? email
+      end
+
+      private
+
+      attr_reader :current_user
+
+      def log_action(user)
+        Decidim.traceability.perform_action!(
+          "invite",
+          user,
+          current_user,
+          extra: {
+            invited_user_role: "participant",
+            invited_user_id: user.id
+          }
+        )
+      end
+    end
+  end
+end

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -15,7 +15,7 @@ module Decidim
           return
         end
 
-        return unless authorization.granted?
+        return unless valid_authorization?
 
         Verification::DestroyUserAuthorization.call(authorization) do
           on(:ok) do
@@ -36,10 +36,11 @@ module Decidim
       end
 
       def authorization
-        @authorization ||= Authorization.find_or_initialize_by(
-          user: user,
-          name: :direct_verifications
-        )
+        @authorization ||= Authorization.find_by(user: user, name: :direct_verifications)
+      end
+
+      def valid_authorization?
+        authorization&.granted?
       end
     end
   end

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -21,9 +21,6 @@ module Decidim
           on(:ok) do
             instrumenter.add_processed :revoked, email
           end
-          on(:invalid) do
-            add_error :revoked, email
-          end
         end
       end
 

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class RevokeUser
+      def initialize(email, organization, instrumenter)
+        @email = email
+        @organization = organization
+        @instrumenter = instrumenter
+      end
+
+      def call
+        if (u = find_user)
+          auth = authorization(u)
+          return unless auth.granted?
+
+          Verification::DestroyUserAuthorization.call(auth) do
+            on(:ok) do
+              instrumenter.add_processed :revoked, email
+            end
+            on(:invalid) do
+              add_error :revoked, email
+            end
+          end
+        else
+          instrumenter.add_error :revoked, email
+        end
+      end
+
+      private
+
+      attr_reader :email, :organization, :instrumenter
+
+      def find_user
+        User.find_by(email: email, decidim_organization_id: organization.id)
+      end
+
+      def authorization(user)
+        Authorization.find_or_initialize_by(
+          user: user,
+          name: :direct_verifications
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
@@ -15,7 +15,7 @@ module Decidim
           let(:user) { create(:user, organization: organization) }
           let(:email) { user.email }
           let(:session) { {} }
-          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+          let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
           context "when passing the user name" do
             let(:data) { user.name }
@@ -108,7 +108,7 @@ module Decidim
           let(:email) { "em@mail.com" }
           let(:data) { "Andy" }
           let(:session) { {} }
-          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+          let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
           it "tracks an error" do
             subject.call

--- a/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe AuthorizeUser do
+      subject { described_class.new(email, data, session, organization, instrumenter) }
+
+      describe "#call" do
+        context "when authorizing confirmed users" do
+          let(:organization) { build(:organization) }
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+          let(:session) { {} }
+          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+
+          context "when passing the user name" do
+            let(:data) { user.name }
+
+            it "tracks the operation" do
+              subject.call
+
+              expect(instrumenter).to have_received(:add_processed).with(:authorized, email)
+              expect(instrumenter).not_to have_received(:add_error)
+            end
+
+            it "authorizes the user" do
+              expect(Verification::ConfirmUserAuthorization).to receive(:call)
+              subject.call
+            end
+          end
+
+          context "when passing user data" do
+            let(:data) { { name: user.name, type: "consumer" } }
+
+            it "stores it as authorization metadata" do
+              subject.call
+              expect(Authorization.last.metadata).to eq("name" => user.name, "type" => "consumer")
+            end
+
+            it "authorizes the user" do
+              expect(Verification::ConfirmUserAuthorization).to receive(:call)
+              subject.call
+            end
+          end
+
+          context "when the user fails to be authorized" do
+            let(:form) { instance_double(Verification::DirectVerificationsForm, valid?: false) }
+            let(:data) { user.name }
+
+            before do
+              allow(Verification::DirectVerificationsForm)
+                .to receive(:new).with(email: user.email, name: user.name) { form }
+            end
+
+            it "tracks the error" do
+              subject.call
+              expect(instrumenter).to have_received(:add_error).with(:authorized, email)
+            end
+          end
+        end
+
+        context "when authorizing unregistered users" do
+          let(:organization) { build(:organization) }
+          let(:user) { nil }
+          let(:email) { "em@mail.com" }
+          let(:data) { "Andy" }
+          let(:session) { {} }
+          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+
+          it "tracks an error" do
+            subject.call
+
+            expect(instrumenter).not_to have_received(:add_processed)
+            expect(instrumenter).to have_received(:add_error).with(:authorized, email)
+          end
+
+          it "does not authorize the user" do
+            expect(Verification::ConfirmUserAuthorization).not_to receive(:call)
+            subject.call
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/register_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/register_user_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:user) { build(:user) }
       let(:organization) { build(:organization) }
-      let(:instrumenter) { instance_double(UserProcessor, track: true) }
+      let(:instrumenter) { instance_double(Instrumenter, track: true) }
 
       let(:email) { "em@il.com" }
       let(:name) { "Joni" }

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       describe "#call" do
         let(:organization) { build(:organization) }
-        let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+        let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
         context "when revoking existing users" do
           let(:user) { create(:user, organization: organization) }

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe RevokeUser do
+      subject { described_class.new(email, organization, instrumenter) }
+
+      describe "#call" do
+        let(:organization) { build(:organization) }
+        let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+
+        context "when revoking existing users" do
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+
+          before { create(:authorization, :granted, user: user, name: :direct_verifications) }
+
+          it "tracks the operation" do
+            subject.call
+            expect(instrumenter).to have_received(:add_processed).with(:revoked, email)
+          end
+
+          it "revokes the user authorization" do
+            expect(Verification::DestroyUserAuthorization).to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when revoking non-existing users" do
+          let(:email) { "em@mail.com" }
+
+          it "tracks the error" do
+            subject.call
+            expect(instrumenter).to have_received(:add_error).with(:revoked, email)
+          end
+
+          it "does not revoke the authorization" do
+            expect(Verification::DestroyUserAuthorization).not_to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when the authorization does not exist" do
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+
+          it "does not track the operation" do
+            subject.call
+            expect(instrumenter).not_to have_received(:add_processed)
+            expect(instrumenter).not_to have_received(:add_error)
+          end
+
+          it "does not revoke the authorization" do
+            expect(Verification::DestroyUserAuthorization).not_to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when the authorization is not granted" do
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+
+          before { create(:authorization, :pending, user: user, name: :direct_verifications) }
+
+          it "does not track the operation" do
+            subject.call
+            expect(instrumenter).not_to have_received(:add_processed)
+            expect(instrumenter).not_to have_received(:add_error)
+          end
+
+          it "does not revoke the authorization" do
+            expect(Verification::DestroyUserAuthorization).not_to receive(:call)
+            subject.call
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -75,6 +75,24 @@ module Decidim
             subject.call
           end
         end
+
+        context "when the authorization fails to be destroyed" do
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+          let(:authorization) { create(:authorization, :granted, user: user, name: :direct_verifications) }
+
+          before do
+            allow(authorization).to receive(:destroy!).and_raise(ActiveRecord::ActiveRecordError)
+            allow(Authorization)
+              .to receive(:find_by)
+              .with(user: user, name: :direct_verifications)
+              .and_return(authorization)
+          end
+
+          it "lets lower-level exceptions to pass through" do
+            expect { subject.call }.to raise_error(ActiveRecord::ActiveRecordError)
+          end
+        end
       end
     end
   end

--- a/spec/lib/decidim/direct_verifications/user_processor_spec.rb
+++ b/spec/lib/decidim/direct_verifications/user_processor_spec.rb
@@ -34,22 +34,24 @@ module Decidim
 
       context "when add processed" do
         it "has unique emails per type" do
-          subject.send(:add_processed, :registered, "em@il.com")
-          subject.send(:add_processed, :registered, "em@il.com")
+          subject.add_processed(:registered, "em@il.com")
+          subject.add_processed(:registered, "em@il.com")
           expect(subject.processed[:registered].count).to eq(1)
-          subject.send(:add_processed, :authorized, "em@il.com")
-          subject.send(:add_processed, :authorized, "em@il.com")
+
+          subject.add_processed(:authorized, "em@il.com")
+          subject.add_processed(:authorized, "em@il.com")
           expect(subject.processed[:authorized].count).to eq(1)
         end
       end
 
       context "when add errors" do
         it "has unique emails per type" do
-          subject.send(:add_error, :registered, "em@il.com")
-          subject.send(:add_error, :registered, "em@il.com")
+          subject.add_error(:registered, "em@il.com")
+          subject.add_error(:registered, "em@il.com")
           expect(subject.errors[:registered].count).to eq(1)
-          subject.send(:add_error, :authorized, "em@il.com")
-          subject.send(:add_error, :authorized, "em@il.com")
+
+          subject.add_error(:authorized, "em@il.com")
+          subject.add_error(:authorized, "em@il.com")
           expect(subject.errors[:authorized].count).to eq(1)
         end
       end

--- a/spec/lib/decidim/direct_verifications/user_processor_spec.rb
+++ b/spec/lib/decidim/direct_verifications/user_processor_spec.rb
@@ -163,36 +163,6 @@ module Decidim
           expect(subject.errors[:revoked].count).to eq(1)
         end
       end
-
-      context "when the authorization does not exist" do
-        before do
-          create(:user, email: "em@il.com", organization: organization)
-          subject.emails = ["em@il.com"]
-        end
-
-        it "has no errors" do
-          subject.revoke_users
-
-          expect(subject.processed[:revoked].count).to eq(0)
-          expect(subject.errors[:revoked].count).to eq(0)
-        end
-      end
-
-      context "when the authorization is not granted" do
-        let(:user) { create(:user, email: "em@il.com", organization: organization) }
-
-        before do
-          subject.emails = ["em@il.com"]
-          create(:authorization, :pending, user: user, name: :direct_verifications)
-        end
-
-        it "has no errors" do
-          subject.revoke_users
-
-          expect(subject.processed[:revoked].count).to eq(0)
-          expect(subject.errors[:revoked].count).to eq(0)
-        end
-      end
     end
   end
 end

--- a/spec/lib/decidim/direct_verifications/user_processor_spec.rb
+++ b/spec/lib/decidim/direct_verifications/user_processor_spec.rb
@@ -5,13 +5,14 @@ require "spec_helper"
 module Decidim
   module DirectVerifications
     describe UserProcessor do
-      subject { described_class.new(organization, user, session) }
+      subject { described_class.new(organization, user, session, instrumenter) }
 
       let(:user) { create(:user, :confirmed, :admin, organization: organization) }
       let(:session) { double(:session) }
       let(:organization) do
         create(:organization, available_authorizations: ["direct_verifications"])
       end
+      let(:instrumenter) { Instrumenter.new(nil) }
 
       context "when emails are passed" do
         it "uses the specified name" do
@@ -34,29 +35,31 @@ module Decidim
 
       context "when add processed" do
         it "has unique emails per type" do
-          subject.add_processed(:registered, "em@il.com")
-          subject.add_processed(:registered, "em@il.com")
-          expect(subject.processed[:registered].count).to eq(1)
+          instrumenter.add_processed(:registered, "em@il.com")
+          instrumenter.add_processed(:registered, "em@il.com")
+          expect(instrumenter.processed[:registered].count).to eq(1)
 
-          subject.add_processed(:authorized, "em@il.com")
-          subject.add_processed(:authorized, "em@il.com")
-          expect(subject.processed[:authorized].count).to eq(1)
+          instrumenter.add_processed(:authorized, "em@il.com")
+          instrumenter.add_processed(:authorized, "em@il.com")
+          expect(instrumenter.processed[:authorized].count).to eq(1)
         end
       end
 
       context "when add errors" do
         it "has unique emails per type" do
-          subject.add_error(:registered, "em@il.com")
-          subject.add_error(:registered, "em@il.com")
-          expect(subject.errors[:registered].count).to eq(1)
+          instrumenter.add_error(:registered, "em@il.com")
+          instrumenter.add_error(:registered, "em@il.com")
+          expect(instrumenter.errors[:registered].count).to eq(1)
 
-          subject.add_error(:authorized, "em@il.com")
-          subject.add_error(:authorized, "em@il.com")
-          expect(subject.errors[:authorized].count).to eq(1)
+          instrumenter.add_error(:authorized, "em@il.com")
+          instrumenter.add_error(:authorized, "em@il.com")
+          expect(instrumenter.errors[:authorized].count).to eq(1)
         end
       end
 
       describe "#register_users" do
+        subject { described_class.new(organization, user, session, instrumenter) }
+
         context "when registering valid users" do
           before do
             subject.emails = ["em@il.com", "em@il.com", "em@il.net"]
@@ -64,8 +67,8 @@ module Decidim
           end
 
           it "has no errors" do
-            expect(subject.processed[:registered].count).to eq(2)
-            expect(subject.errors[:registered].count).to eq(0)
+            expect(instrumenter.processed[:registered].count).to eq(2)
+            expect(instrumenter.errors[:registered].count).to eq(0)
           end
         end
 
@@ -76,8 +79,8 @@ module Decidim
           end
 
           it "has no errors" do
-            expect(subject.processed[:registered].count).to eq(1)
-            expect(subject.errors[:registered].count).to eq(0)
+            expect(instrumenter.processed[:registered].count).to eq(1)
+            expect(instrumenter.errors[:registered].count).to eq(0)
           end
         end
       end
@@ -91,8 +94,8 @@ module Decidim
           it "has no errors" do
             subject.authorize_users
 
-            expect(subject.processed[:authorized].count).to eq(1)
-            expect(subject.errors[:authorized].count).to eq(0)
+            expect(instrumenter.processed[:authorized].count).to eq(1)
+            expect(instrumenter.errors[:authorized].count).to eq(0)
           end
         end
 
@@ -116,8 +119,8 @@ module Decidim
           it "has no errors" do
             subject.authorize_users
 
-            expect(subject.processed[:authorized].count).to eq(1)
-            expect(subject.errors[:authorized].count).to eq(0)
+            expect(instrumenter.processed[:authorized].count).to eq(1)
+            expect(instrumenter.errors[:authorized].count).to eq(0)
           end
         end
 
@@ -145,8 +148,8 @@ module Decidim
         it "has no errors" do
           subject.revoke_users
 
-          expect(subject.processed[:revoked].count).to eq(1)
-          expect(subject.errors[:revoked].count).to eq(0)
+          expect(instrumenter.processed[:revoked].count).to eq(1)
+          expect(instrumenter.errors[:revoked].count).to eq(0)
         end
       end
 
@@ -159,8 +162,8 @@ module Decidim
         it "has errors" do
           subject.revoke_users
 
-          expect(subject.processed[:revoked].count).to eq(0)
-          expect(subject.errors[:revoked].count).to eq(1)
+          expect(instrumenter.processed[:revoked].count).to eq(0)
+          expect(instrumenter.errors[:revoked].count).to eq(1)
         end
       end
     end


### PR DESCRIPTION
Extracts an `Instrumenter` class out of `UserProcessor`. This a separate responsibility that deserves its own class and which hampers `UserProcessor` 's changeability. As a result, implementing async processing will be even easier.

The last commit is the only addition to #23 . It'll be easier to ship #21 and #22 first.