### PR TITLE
Async csv import

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -34,7 +34,7 @@ module Decidim
         attr_reader :form, :file, :organization, :user, :action
 
         def register_users_async
-          RegisterUsersJob.perform_later(file.read, organization, user)
+          RegisterUsersJob.perform_later(file.read, organization, user, form.authorization_handler)
         end
 
         def revoke_users_async

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -4,20 +4,23 @@ module Decidim
   module DirectVerifications
     module Verification
       class CreateImport < Rectify::Command
-        def initialize(file, organization, user)
-          @file = file
-          @organization = organization
-          @user = user
+        def initialize(form)
+          @form = form
+          @file = form.file
+          @organization = form.organization
+          @user = form.user
         end
 
         def call
+          return broadcast(:invalid) unless form.valid?
+
           register_users_async
           broadcast(:ok)
         end
 
         private
 
-        attr_reader :file, :organization, :user
+        attr_reader :form, :file, :organization, :user
 
         def register_users_async
           RegisterUsersJob.perform_later(file.read, organization, user)

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -38,7 +38,7 @@ module Decidim
         end
 
         def revoke_users_async
-          RevokeUsersJob.perform_later(file.read, organization, user)
+          RevokeUsersJob.perform_later(file.read, organization, user, form.authorization_handler)
         end
 
         def authorize_users_async

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    module Verification
+      class CreateImport < Rectify::Command
+        def initialize(file, organization, user)
+          @file = file
+          @organization = organization
+          @user = user
+        end
+
+        def call
+          register_users_async
+          broadcast(:ok)
+        end
+
+        private
+
+        attr_reader :file, :organization, :user
+
+        def register_users_async
+          RegisterUsersJob.perform_later(file.read, organization, user)
+        end
+      end
+    end
+  end
+end

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -34,15 +34,15 @@ module Decidim
         attr_reader :form, :file, :organization, :user, :action
 
         def register_users_async
-          RegisterUsersJob.perform_later(file.read, organization, user)
+          RegisterUsersJob.perform_later(file.path, organization, user)
         end
 
         def revoke_users_async
-          RevokeUsersJob.perform_later(file.read, organization, user)
+          RevokeUsersJob.perform_later(file.path, organization, user)
         end
 
         def authorize_users_async
-          AuthorizeUsersJob.perform_later(file.read, organization, user)
+          AuthorizeUsersJob.perform_later(file.path, organization, user)
         end
       end
     end

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -18,6 +18,10 @@ module Decidim
           case action
           when :register
             register_users_async
+          when :register_and_authorize
+            register_users_async
+            file.rewind
+            authorize_users_async
           when :revoke
             revoke_users_async
           end
@@ -35,6 +39,10 @@ module Decidim
 
         def revoke_users_async
           RevokeUsersJob.perform_later(file.read, organization, user)
+        end
+
+        def authorize_users_async
+          AuthorizeUsersJob.perform_later(file.read, organization, user)
         end
       end
     end

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -42,7 +42,7 @@ module Decidim
         end
 
         def authorize_users_async
-          AuthorizeUsersJob.perform_later(file.read, organization, user)
+          AuthorizeUsersJob.perform_later(file.read, organization, user, form.authorization_handler)
         end
       end
     end

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -34,15 +34,15 @@ module Decidim
         attr_reader :form, :file, :organization, :user, :action
 
         def register_users_async
-          RegisterUsersJob.perform_later(file.path, organization, user)
+          RegisterUsersJob.perform_later(file.read, organization, user)
         end
 
         def revoke_users_async
-          RevokeUsersJob.perform_later(file.path, organization, user)
+          RevokeUsersJob.perform_later(file.read, organization, user)
         end
 
         def authorize_users_async
-          AuthorizeUsersJob.perform_later(file.path, organization, user)
+          AuthorizeUsersJob.perform_later(file.read, organization, user)
         end
       end
     end

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -9,21 +9,32 @@ module Decidim
           @file = form.file
           @organization = form.organization
           @user = form.user
+          @action = form.action
         end
 
         def call
           return broadcast(:invalid) unless form.valid?
 
-          register_users_async
+          case action
+          when :register
+            register_users_async
+          when :revoke
+            revoke_users_async
+          end
+
           broadcast(:ok)
         end
 
         private
 
-        attr_reader :form, :file, :organization, :user
+        attr_reader :form, :file, :organization, :user, :action
 
         def register_users_async
           RegisterUsersJob.perform_later(file.read, organization, user)
+        end
+
+        def revoke_users_async
+          RevokeUsersJob.perform_later(file.read, organization, user)
         end
       end
     end

--- a/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
+++ b/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
@@ -40,8 +40,10 @@ module Decidim
         end
 
         def normalize_header(line)
-          line.map do |text|
-            text.to_sym.downcase
+          line.map do |field|
+            raise MissingHeaderError if field.nil?
+
+            field.to_sym.downcase
           end
         end
       end

--- a/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
+++ b/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
@@ -24,8 +24,7 @@ module Decidim
           hash = {}
           header.each_with_index do |column, index|
             value = tokens[index]
-            next if value.nil?
-            next if value.include?(email)
+            next if value&.include?(email)
 
             hash[column] = value
           end
@@ -36,11 +35,7 @@ module Decidim
 
         def tokenize(line)
           CSV.parse_line(line).map do |token|
-            if token.nil?
-              nil
-            else
-              token.strip
-            end
+            token&.strip
           end
         end
 

--- a/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
+++ b/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
@@ -9,8 +9,8 @@ module Decidim
         def header
           @header ||= begin
                         header_row = lines[0].chomp
-                        column_names = tokenize(header_row)
-                        column_names.map(&:to_sym).map(&:downcase)
+                        header_row = tokenize(header_row)
+                        normalize_header(header_row)
                       end
         end
 
@@ -23,7 +23,7 @@ module Decidim
 
           hash = {}
           header.each_with_index do |column, index|
-            value = tokens[index].strip
+            value = tokens[index]
             next if value.include?(email)
 
             hash[column] = value
@@ -34,7 +34,13 @@ module Decidim
         private
 
         def tokenize(line)
-          CSV.parse(line)[0]
+          CSV.parse(line)[0].map(&:strip)
+        end
+
+        def normalize_header(line)
+          line.map do |text|
+            text.to_sym.downcase
+          end
         end
       end
     end

--- a/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
+++ b/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
@@ -24,6 +24,7 @@ module Decidim
           hash = {}
           header.each_with_index do |column, index|
             value = tokens[index]
+            next if value.nil?
             next if value.include?(email)
 
             hash[column] = value
@@ -34,7 +35,13 @@ module Decidim
         private
 
         def tokenize(line)
-          CSV.parse(line)[0].map(&:strip)
+          CSV.parse_line(line).map do |token|
+            if token.nil?
+              nil
+            else
+              token.strip
+            end
+          end
         end
 
         def normalize_header(line)

--- a/app/commands/decidim/direct_verifications/verification/missing_header_error.rb
+++ b/app/commands/decidim/direct_verifications/verification/missing_header_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    module Verification
+      class MissingHeaderError < StandardError
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
@@ -18,11 +18,14 @@ module Decidim
             enforce_permission_to :create, :authorization
 
             @userslist = params[:userslist]
-            @processor = UserProcessor.new(current_organization, current_user, session)
+
+            @processor = UserProcessor.new(current_organization, current_user, session, instrumenter)
             @processor.emails = parser_class.new(@userslist).to_h
             @processor.authorization_handler = current_authorization_handler
+
             @stats = UserStats.new(current_organization)
             @stats.authorization_handler = @processor.authorization_handler
+
             register_users
             authorize_users
             revoke_users
@@ -34,13 +37,17 @@ module Decidim
 
           private
 
+          def instrumenter
+            @instrumenter ||= Instrumenter.new(current_user)
+          end
+
           def register_users
             return unless params[:register]
 
             @processor.register_users
             flash[:warning] = t(".registered", count: @processor.emails.count,
-                                               registered: @processor.processed[:registered].count,
-                                               errors: @processor.errors[:registered].count)
+                                               registered: instrumenter.processed[:registered].count,
+                                               errors: instrumenter.errors[:registered].count)
           end
 
           def authorize_users
@@ -49,8 +56,8 @@ module Decidim
             @processor.authorize_users
             flash[:notice] = t(".authorized", handler: t("#{@processor.authorization_handler}.name", scope: "decidim.authorization_handlers"),
                                               count: @processor.emails.count,
-                                              authorized: @processor.processed[:authorized].count,
-                                              errors: @processor.errors[:authorized].count)
+                                              authorized: instrumenter.processed[:authorized].count,
+                                              errors: instrumenter.errors[:authorized].count)
           end
 
           def revoke_users
@@ -59,8 +66,8 @@ module Decidim
             @processor.revoke_users
             flash[:notice] = t(".revoked", handler: t("#{@processor.authorization_handler}.name", scope: "decidim.authorization_handlers"),
                                            count: @processor.emails.count,
-                                           revoked: @processor.processed[:revoked].count,
-                                           errors: @processor.errors[:revoked].count)
+                                           revoked: instrumenter.processed[:revoked].count,
+                                           errors: instrumenter.errors[:revoked].count)
           end
 
           def show_users_info

--- a/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
@@ -10,6 +10,8 @@ module Decidim
 
           layout "decidim/admin/users"
 
+          I18N_SCOPE = "decidim.direct_verifications.verification.admin.direct_verifications"
+
           def index
             enforce_permission_to :index, :authorization
           end
@@ -32,6 +34,9 @@ module Decidim
 
             render(action: :index) && return if show_users_info
 
+            redirect_to direct_verifications_path
+          rescue MissingHeaderError => _e
+            flash[:error] = I18n.t("#{I18N_SCOPE}.create.missing_header")
             redirect_to direct_verifications_path
           end
 

--- a/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
@@ -46,8 +46,8 @@ module Decidim
 
             @processor.register_users
             flash[:warning] = t(".registered", count: @processor.emails.count,
-                                               registered: instrumenter.processed[:registered].count,
-                                               errors: instrumenter.errors[:registered].count)
+                                               registered: instrumenter.processed_count(:registered),
+                                               errors: instrumenter.errors_count(:registered))
           end
 
           def authorize_users
@@ -56,8 +56,8 @@ module Decidim
             @processor.authorize_users
             flash[:notice] = t(".authorized", handler: t("#{@processor.authorization_handler}.name", scope: "decidim.authorization_handlers"),
                                               count: @processor.emails.count,
-                                              authorized: instrumenter.processed[:authorized].count,
-                                              errors: instrumenter.errors[:authorized].count)
+                                              authorized: instrumenter.processed_count(:authorized),
+                                              errors: instrumenter.errors_count(:authorized))
           end
 
           def revoke_users
@@ -66,8 +66,8 @@ module Decidim
             @processor.revoke_users
             flash[:notice] = t(".revoked", handler: t("#{@processor.authorization_handler}.name", scope: "decidim.authorization_handlers"),
                                            count: @processor.emails.count,
-                                           revoked: instrumenter.processed[:revoked].count,
-                                           errors: instrumenter.errors[:revoked].count)
+                                           revoked: instrumenter.processed_count(:revoked),
+                                           errors: instrumenter.errors_count(:revoked))
           end
 
           def show_users_info

--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -5,9 +5,13 @@ module Decidim
     module Verification
       module Admin
         class ImportsController < Decidim::Admin::ApplicationController
-          def new; end
+          def new
+            enforce_permission_to :create, :authorization
+          end
 
           def create
+            enforce_permission_to :create, :authorization
+
             CreateImport.call(params[:file], current_organization, current_user) do
               on(:ok) do
                 flash[:notice] = t(".success")

--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -6,6 +6,7 @@ module Decidim
       module Admin
         class ImportsController < Decidim::Admin::ApplicationController
           layout "decidim/admin/users"
+          helper_method :workflows, :current_authorization_handler
 
           def new
             enforce_permission_to :create, :authorization
@@ -29,6 +30,23 @@ module Decidim
             end
 
             redirect_to new_import_path
+          end
+
+          def workflows
+            workflows = configured_workflows & current_organization.available_authorizations.map.to_a
+            workflows.map do |workflow|
+              [t("#{workflow}.name", scope: "decidim.authorization_handlers"), workflow]
+            end
+          end
+
+          def configured_workflows
+            return Decidim::DirectVerifications.config.manage_workflows if Decidim::DirectVerifications.config
+
+            ["direct_verifications"]
+          end
+
+          def current_authorization_handler
+            params[:authorization_handler]
           end
         end
       end

--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -12,12 +12,20 @@ module Decidim
           def create
             enforce_permission_to :create, :authorization
 
-            CreateImport.call(params[:file], current_organization, current_user) do
+            defaults = { organization: current_organization, user: current_user }
+            form = form(CreateImportForm).from_params(params.merge(defaults))
+
+            CreateImport.call(form) do
               on(:ok) do
                 flash[:notice] = t(".success")
-                redirect_to decidim_admin_direct_verifications.new_import_path
+              end
+
+              on(:invalid) do
+                flash[:alert] = t(".error")
               end
             end
+
+            redirect_to new_import_path
           end
         end
       end

--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    module Verification
+      module Admin
+        class ImportsController < Decidim::Admin::ApplicationController
+          def new; end
+
+          def create
+            userslist = params[:file].read
+            RegisterUsersJob.perform_later(userslist, current_organization, current_user)
+
+            flash[:notice] = t(".success")
+            redirect_to decidim_admin_direct_verifications.new_import_path
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -8,11 +8,12 @@ module Decidim
           def new; end
 
           def create
-            userslist = params[:file].read
-            RegisterUsersJob.perform_later(userslist, current_organization, current_user)
-
-            flash[:notice] = t(".success")
-            redirect_to decidim_admin_direct_verifications.new_import_path
+            CreateImport.call(params[:file], current_organization, current_user) do
+              on(:ok) do
+                flash[:notice] = t(".success")
+                redirect_to decidim_admin_direct_verifications.new_import_path
+              end
+            end
           end
         end
       end

--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -5,6 +5,8 @@ module Decidim
     module Verification
       module Admin
         class ImportsController < Decidim::Admin::ApplicationController
+          layout "decidim/admin/users"
+
           def new
             enforce_permission_to :create, :authorization
             @form = form(CreateImportForm).instance

--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -7,6 +7,7 @@ module Decidim
         class ImportsController < Decidim::Admin::ApplicationController
           def new
             enforce_permission_to :create, :authorization
+            @form = form(CreateImportForm).instance
           end
 
           def create

--- a/app/forms/decidim/direct_verifications/verification/create_import_form.rb
+++ b/app/forms/decidim/direct_verifications/verification/create_import_form.rb
@@ -13,9 +13,9 @@ module Decidim
         attribute :file
         attribute :organization, Decidim::Organization
         attribute :user, Decidim::User
-        attribute :authorize
+        attribute :authorize, String
 
-        validates :file, :organization, :user, presence: true
+        validates :file, :organization, :user, :authorize, presence: true
         validates :authorize, inclusion: { in: ACTIONS.keys }
 
         def action

--- a/app/forms/decidim/direct_verifications/verification/create_import_form.rb
+++ b/app/forms/decidim/direct_verifications/verification/create_import_form.rb
@@ -5,7 +5,7 @@ module Decidim
     module Verification
       class CreateImportForm < Form
         ACTIONS = {
-          "in" => :register,
+          "in" => :authorize,
           "out" => :revoke,
           "check" => :check
         }.freeze
@@ -14,12 +14,19 @@ module Decidim
         attribute :organization, Decidim::Organization
         attribute :user, Decidim::User
         attribute :authorize, String
+        attribute :register, Boolean
 
         validates :file, :organization, :user, :authorize, presence: true
         validates :authorize, inclusion: { in: ACTIONS.keys }
 
         def action
-          ACTIONS[authorize]
+          if register && authorize == "in"
+            :register_and_authorize
+          elsif register
+            :register
+          else
+            ACTIONS[authorize]
+          end
         end
       end
     end

--- a/app/forms/decidim/direct_verifications/verification/create_import_form.rb
+++ b/app/forms/decidim/direct_verifications/verification/create_import_form.rb
@@ -15,9 +15,18 @@ module Decidim
         attribute :user, Decidim::User
         attribute :authorize, String
         attribute :register, Boolean
+        attribute :authorization_handler, String
 
-        validates :file, :organization, :user, :authorize, presence: true
+        validates :file, :organization, :user, :authorize, :authorization_handler, presence: true
         validates :authorize, inclusion: { in: ACTIONS.keys }
+
+        validate :available_authorization_handler
+
+        def available_authorization_handler
+          return if authorization_handler.in?(organization.available_authorizations)
+
+          errors.add(:authorization_handler, :inclusion)
+        end
 
         def action
           if register && authorize == "in"

--- a/app/forms/decidim/direct_verifications/verification/create_import_form.rb
+++ b/app/forms/decidim/direct_verifications/verification/create_import_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    module Verification
+      class CreateImportForm < Form
+        attribute :file
+
+        attribute :organization, Decidim::Organization
+        attribute :user, Decidim::User
+
+        validates :file, :organization, :user, presence: true
+      end
+    end
+  end
+end

--- a/app/forms/decidim/direct_verifications/verification/create_import_form.rb
+++ b/app/forms/decidim/direct_verifications/verification/create_import_form.rb
@@ -4,12 +4,23 @@ module Decidim
   module DirectVerifications
     module Verification
       class CreateImportForm < Form
-        attribute :file
+        ACTIONS = {
+          "in" => :register,
+          "out" => :revoke,
+          "check" => :check
+        }.freeze
 
+        attribute :file
         attribute :organization, Decidim::Organization
         attribute :user, Decidim::User
+        attribute :authorize
 
         validates :file, :organization, :user, presence: true
+        validates :authorize, inclusion: { in: ACTIONS.keys }
+
+        def action
+          ACTIONS[authorize]
+        end
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/authorize_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/authorize_users_job.rb
@@ -9,7 +9,14 @@ module Decidim
 
       def process_users
         emails.each do |email, data|
-          AuthorizeUser.new(email, data, session, organization, instrumenter).call
+          AuthorizeUser.new(
+            email,
+            data,
+            session,
+            organization,
+            instrumenter,
+            authorization_handler
+          ).call
         end
       end
 

--- a/app/jobs/decidim/direct_verifications/authorize_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/authorize_users_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "decidim/direct_verifications/instrumenter"
+
+module Decidim
+  module DirectVerifications
+    class AuthorizeUsersJob < BaseImportJob
+      class NullSession; end
+
+      def process_users
+        emails.each do |email, data|
+          AuthorizeUser.new(email, data, session, organization, instrumenter).call
+        end
+      end
+
+      def type
+        :authorized
+      end
+
+      private
+
+      def session
+        NullSession.new
+      end
+    end
+  end
+end

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -4,6 +4,9 @@ require "decidim/direct_verifications/instrumenter"
 
 module Decidim
   module DirectVerifications
+    # This class implements the logic to import the user entries and sending an email notification
+    # with the result. The specifics to process the entries are meant to be implemented by
+    # subclasses which must implement the `#process_users` and `#type` methods.
     class BaseImportJob < ApplicationJob
       queue_as :default
 
@@ -20,6 +23,10 @@ module Decidim
       private
 
       attr_reader :emails, :organization, :current_user, :instrumenter
+
+      def send_email_notification
+        ImportMailer.finished_processing(current_user, instrumenter, type).deliver_now
+      end
     end
   end
 end

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "decidim/direct_verifications/instrumenter"
+
+module Decidim
+  module DirectVerifications
+    class BaseImportJob < ApplicationJob
+      queue_as :default
+
+      def perform(userslist, organization, current_user)
+        @emails = Verification::MetadataParser.new(userslist).to_h
+        @organization = organization
+        @current_user = current_user
+        @instrumenter = Instrumenter.new(current_user)
+
+        process_users
+        send_email_notification
+      end
+
+      private
+
+      attr_reader :emails, :organization, :current_user, :instrumenter
+    end
+  end
+end

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -10,7 +10,8 @@ module Decidim
     class BaseImportJob < ApplicationJob
       queue_as :default
 
-      def perform(userslist, organization, current_user)
+      def perform(path, organization, current_user)
+        userslist = File.read(path)
         @emails = Verification::MetadataParser.new(userslist).to_h
         @organization = organization
         @current_user = current_user

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -10,8 +10,7 @@ module Decidim
     class BaseImportJob < ApplicationJob
       queue_as :default
 
-      def perform(path, organization, current_user)
-        userslist = File.read(path)
+      def perform(userslist, organization, current_user)
         @emails = Verification::MetadataParser.new(userslist).to_h
         @organization = organization
         @current_user = current_user

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -10,7 +10,7 @@ module Decidim
     class BaseImportJob < ApplicationJob
       queue_as :default
 
-      def perform(userslist, organization, current_user, authorization_handler = :direct_verifications)
+      def perform(userslist, organization, current_user, authorization_handler)
         @emails = Verification::MetadataParser.new(userslist).to_h
         @organization = organization
         @current_user = current_user

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -10,11 +10,12 @@ module Decidim
     class BaseImportJob < ApplicationJob
       queue_as :default
 
-      def perform(userslist, organization, current_user)
+      def perform(userslist, organization, current_user, authorization_handler = :direct_verifications)
         @emails = Verification::MetadataParser.new(userslist).to_h
         @organization = organization
         @current_user = current_user
         @instrumenter = Instrumenter.new(current_user)
+        @authorization_handler = authorization_handler
 
         process_users
         send_email_notification
@@ -22,10 +23,15 @@ module Decidim
 
       private
 
-      attr_reader :emails, :organization, :current_user, :instrumenter
+      attr_reader :emails, :organization, :current_user, :instrumenter, :authorization_handler
 
       def send_email_notification
-        ImportMailer.finished_processing(current_user, instrumenter, type).deliver_now
+        ImportMailer.finished_processing(
+          current_user,
+          instrumenter,
+          type,
+          authorization_handler
+        ).deliver_now
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -33,7 +33,7 @@ module Decidim
       end
 
       def send_email_notification
-        ImportMailer.successful_import(current_user).deliver_now
+        ImportMailer.finished_registration(current_user, instrumenter).deliver_now
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -4,24 +4,8 @@ require "decidim/direct_verifications/instrumenter"
 
 module Decidim
   module DirectVerifications
-    class RegisterUsersJob < ApplicationJob
-      queue_as :default
-
-      def perform(userslist, organization, user)
-        @emails = Verification::MetadataParser.new(userslist).to_h
-        @organization = organization
-        @current_user = user
-        @instrumenter = Instrumenter.new(current_user)
-
-        register_users
-        send_email_notification
-      end
-
-      private
-
-      attr_reader :organization, :current_user, :instrumenter, :emails
-
-      def register_users
+    class RegisterUsersJob < BaseImportJob
+      def process_users
         emails.each do |email, data|
           name = if data.is_a?(Hash)
                    data[:name]

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -33,7 +33,7 @@ module Decidim
       end
 
       def send_email_notification
-        ImportMailer.finished_registration(current_user, instrumenter).deliver_now
+        ImportMailer.finished_processing(current_user, instrumenter, :registered).deliver_now
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "decidim/direct_verifications/instrumenter"
+
+module Decidim
+  module DirectVerifications
+    class RegisterUsersJob < ApplicationJob
+      queue_as :default
+
+      def perform(userslist, organization, user)
+        @emails = Verification::MetadataParser.new(userslist).to_h
+        @organization = organization
+        @current_user = user
+        @instrumenter = Instrumenter.new(current_user)
+
+        register_users
+      end
+
+      private
+
+      attr_reader :organization, :current_user, :instrumenter, :emails
+
+      def register_users
+        emails.each do |email, data|
+          name = if data.is_a?(Hash)
+                   data[:name]
+                 else
+                   data
+                 end
+          RegisterUser.new(email, name, organization, current_user, instrumenter).call
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -7,12 +7,7 @@ module Decidim
     class RegisterUsersJob < BaseImportJob
       def process_users
         emails.each do |email, data|
-          name = if data.is_a?(Hash)
-                   data[:name]
-                 else
-                   data
-                 end
-          RegisterUser.new(email, name, organization, current_user, instrumenter).call
+          RegisterUser.new(email, data, organization, current_user, instrumenter).call
         end
       end
 

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -16,8 +16,8 @@ module Decidim
         end
       end
 
-      def send_email_notification
-        ImportMailer.finished_processing(current_user, instrumenter, :registered).deliver_now
+      def type
+        :registered
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -14,6 +14,7 @@ module Decidim
         @instrumenter = Instrumenter.new(current_user)
 
         register_users
+        send_email_notification
       end
 
       private
@@ -29,6 +30,10 @@ module Decidim
                  end
           RegisterUser.new(email, name, organization, current_user, instrumenter).call
         end
+      end
+
+      def send_email_notification
+        ImportMailer.successful_import(current_user).deliver_now
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/revoke_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/revoke_users_job.rb
@@ -5,7 +5,7 @@ module Decidim
     class RevokeUsersJob < BaseImportJob
       def process_users
         emails.each do |email, _name|
-          RevokeUser.new(email, organization, instrumenter).call
+          RevokeUser.new(email, organization, instrumenter, authorization_handler).call
         end
       end
 

--- a/app/jobs/decidim/direct_verifications/revoke_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/revoke_users_job.rb
@@ -9,8 +9,8 @@ module Decidim
         end
       end
 
-      def send_email_notification
-        ImportMailer.finished_processing(current_user, instrumenter, :revoked).deliver_now
+      def type
+        :revoked
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/revoke_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/revoke_users_job.rb
@@ -2,24 +2,8 @@
 
 module Decidim
   module DirectVerifications
-    class RevokeUsersJob < ApplicationJob
-      queue_as :default
-
-      def perform(userslist, organization, current_user)
-        @emails = Verification::MetadataParser.new(userslist).to_h
-        @organization = organization
-        @current_user = current_user
-        @instrumenter = Instrumenter.new(current_user)
-
-        revoke_users
-        send_email_notification
-      end
-
-      private
-
-      attr_reader :emails, :organization, :current_user, :instrumenter
-
-      def revoke_users
+    class RevokeUsersJob < BaseImportJob
+      def process_users
         emails.each do |email, _name|
           RevokeUser.new(email, organization, instrumenter).call
         end

--- a/app/jobs/decidim/direct_verifications/revoke_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/revoke_users_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class RevokeUsersJob < ApplicationJob
+      queue_as :default
+
+      def perform(userslist, organization, current_user)
+        @emails = Verification::MetadataParser.new(userslist).to_h
+        @organization = organization
+        @current_user = current_user
+        @instrumenter = Instrumenter.new(current_user)
+
+        revoke_users
+        send_email_notification
+      end
+
+      private
+
+      attr_reader :emails, :organization, :current_user, :instrumenter
+
+      def revoke_users
+        emails.each do |email, _name|
+          RevokeUser.new(email, organization, instrumenter).call
+        end
+      end
+
+      def send_email_notification
+        ImportMailer.finished_processing(current_user, instrumenter, :revoked).deliver_now
+      end
+    end
+  end
+end

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -3,17 +3,24 @@
 module Decidim
   module DirectVerifications
     class ImportMailer < Decidim::Admin::ApplicationMailer
+      Stats = Struct.new(:count, :registered, :errors, keyword_init: true)
+
       include LocalisedMailer
 
       layout "decidim/mailer"
 
-      def successful_import(user)
+      def finished_registration(user, instrumenter)
         @organization = user.organization
+        @stats = Stats.new(
+          count: instrumenter.emails_count(:registered),
+          registered: instrumenter.processed_count(:registered),
+          errors: instrumenter.errors_count(:registered)
+        )
 
         with_user(user) do
           mail(
             to: user.email,
-            subject: I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject")
+            subject: I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject")
           )
         end
       end

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -5,7 +5,11 @@ module Decidim
     class ImportMailer < Decidim::Admin::ApplicationMailer
       include LocalisedMailer
 
+      layout "decidim/mailer"
+
       def successful_import(user)
+        @organization = user.organization
+
         with_user(user) do
           mail(
             to: user.email,

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -3,24 +3,21 @@
 module Decidim
   module DirectVerifications
     class ImportMailer < Decidim::Admin::ApplicationMailer
-      Stats = Struct.new(:count, :registered, :errors, keyword_init: true)
-
       include LocalisedMailer
 
       layout "decidim/mailer"
 
-      def finished_registration(user, instrumenter)
+      I18N_SCOPE = "decidim.direct_verifications.verification.admin.imports.mailer"
+
+      def finished_processing(user, instrumenter, type)
+        @stats = Stats.from(instrumenter, type)
         @organization = user.organization
-        @stats = Stats.new(
-          count: instrumenter.emails_count(:registered),
-          registered: instrumenter.processed_count(:registered),
-          errors: instrumenter.errors_count(:registered)
-        )
+        @i18n_key = "#{I18N_SCOPE}.#{type}"
 
         with_user(user) do
           mail(
             to: user.email,
-            subject: I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject")
+            subject: I18n.t("#{I18N_SCOPE}.subject")
           )
         end
       end

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -9,10 +9,11 @@ module Decidim
 
       I18N_SCOPE = "decidim.direct_verifications.verification.admin.imports.mailer"
 
-      def finished_processing(user, instrumenter, type)
+      def finished_processing(user, instrumenter, type, handler)
         @stats = Stats.from(instrumenter, type)
         @organization = user.organization
         @i18n_key = "#{I18N_SCOPE}.#{type}"
+        @handler = handler
 
         with_user(user) do
           mail(

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class ImportMailer < Decidim::Admin::ApplicationMailer
+      include LocalisedMailer
+
+      def successful_import(user)
+        with_user(user) do
+          mail(
+            to: user.email,
+            subject: I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject")
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/mailers/decidim/direct_verifications/stats.rb
+++ b/app/mailers/decidim/direct_verifications/stats.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class Stats
+      attr_reader :count, :successful, :errors
+
+      def self.from(instrumenter, type)
+        new(
+          count: instrumenter.emails_count(type),
+          successful: instrumenter.processed_count(type),
+          errors: instrumenter.errors_count(type)
+        )
+      end
+
+      def initialize(count:, successful:, errors:)
+        @count = count
+        @successful = successful
+        @errors = errors
+      end
+    end
+  end
+end

--- a/app/views/decidim/direct_verifications/import_mailer/finished_processing.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_processing.html.erb
@@ -3,5 +3,5 @@
   count: @stats.count,
   successful: @stats.successful,
   errors: @stats.errors,
-  handler: :direct_verifications
+  handler: @handler
 ) %></p>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_processing.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_processing.html.erb
@@ -1,0 +1,7 @@
+<p><%= t(
+  @i18n_key,
+  count: @stats.count,
+  successful: @stats.successful,
+  errors: @stats.errors,
+  handler: :direct_verifications
+) %></p>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_processing.text.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_processing.text.erb
@@ -1,0 +1,7 @@
+<%= t(
+  @i18n_key,
+  count: @stats.count,
+  successful: @stats.successful,
+  errors: @stats.errors,
+  handler: :direct_verifications
+) %>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_processing.text.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_processing.text.erb
@@ -3,5 +3,5 @@
   count: @stats.count,
   successful: @stats.successful,
   errors: @stats.errors,
-  handler: :direct_verifications
+  handler: @handler
 ) %>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_registration.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_registration.html.erb
@@ -1,0 +1,1 @@
+<p><%= t("decidim.direct_verifications.verification.admin.direct_verifications.create.registered", count: @stats.count, registered: @stats.registered, errors: @stats.errors) %></p>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_registration.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_registration.html.erb
@@ -1,1 +1,0 @@
-<p><%= t("decidim.direct_verifications.verification.admin.direct_verifications.create.registered", count: @stats.count, registered: @stats.registered, errors: @stats.errors) %></p>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_registration.text.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_registration.text.erb
@@ -1,1 +1,0 @@
-<%= t("decidim.direct_verifications.verification.admin.direct_verifications.create.registered", count: @stats.count, registered: @stats.registered, errors: @stats.errors) %>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_registration.text.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_registration.text.erb
@@ -1,0 +1,1 @@
+<%= t("decidim.direct_verifications.verification.admin.direct_verifications.create.registered", count: @stats.count, registered: @stats.registered, errors: @stats.errors) %>

--- a/app/views/decidim/direct_verifications/import_mailer/successful_import.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/successful_import.html.erb
@@ -1,1 +1,0 @@
-Register successful

--- a/app/views/decidim/direct_verifications/import_mailer/successful_import.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/successful_import.html.erb
@@ -1,0 +1,1 @@
+Register successful

--- a/app/views/decidim/direct_verifications/verification/admin/direct_verifications/index.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/direct_verifications/index.html.erb
@@ -7,7 +7,7 @@
     </h2>
   </div>
   <div class="card-section">
-    <p><%= t("decidim.direct_verifications.verification.admin.new.info") %></p>
+    <p><%= t("decidim.direct_verifications.verification.admin.new.info_html", link: new_import_path) %></p>
     <%= form_tag direct_verifications_path, multipart: true, class: "form" do %>
       <%= label_tag :userslist, t("admin.new.textarea", scope: "decidim.direct_verifications.verification") %>
       <%= text_area_tag :userslist, @userslist, rows: 10 %>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -7,9 +7,10 @@
     </h2>
   </div>
   <div class="card-section">
-    <p><%= t("decidim.direct_verifications.verification.admin.new.info") %></p>
+    <p><%= t("decidim.direct_verifications.verification.admin.imports.new.info") %></p>
     <pre class="code-block">
-    foo
+      <strong><%= t("decidim.direct_verifications.verification.admin.imports.new.template.header") %></strong>
+      <%= t("decidim.direct_verifications.verification.admin.imports.new.template.body") %>
     </pre>
 
     <%= decidim_form_for(@form, url: imports_path, html: { class: "form" }) do |form| %>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -1,0 +1,46 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t("admin.index.title", scope: "decidim.direct_verifications.verification") %>
+      <%= link_to t("admin.index.stats", scope: "decidim.direct_verifications.verification"), stats_path, class: "button tiny button--title" %>
+      <%= link_to t("admin.index.authorizations", scope: "decidim.direct_verifications.verification"), authorizations_path, class: "button tiny button--title" %>
+    </h2>
+  </div>
+  <div class="card-section">
+    <p><%= t("decidim.direct_verifications.verification.admin.new.info") %></p>
+    <pre class="code-block">
+    foo
+    </pre>
+    <%= form_tag imports_path, multipart: true, class: "form" do %>
+      <%= label_tag :userslist, t("admin.new.textarea", scope: "decidim.direct_verifications.verification") %>
+      <label>
+        <%= check_box_tag :register %>
+        <%= t("admin.new.register", scope: "decidim.direct_verifications.verification") %>
+        <div data-alert class="callout alert hide">
+          <%= t("admin.direct_verifications.gdpr_disclaimer", scope: "decidim.direct_verifications.verification") %>
+        </div>
+      </label>
+      <label>
+        <%= radio_button_tag :authorize, "in" %>
+        <%= t("admin.new.authorize", scope: "decidim.direct_verifications.verification") %>
+      </label>
+      <label>
+        <%= radio_button_tag :authorize, "out" %>
+        <%= t("admin.new.revoke", scope: "decidim.direct_verifications.verification") %>
+      </label>
+      <label>
+        <%= radio_button_tag :authorize, "check", true %>
+        <%= t("admin.new.check", scope: "decidim.direct_verifications.verification") %>
+      </label>
+
+      <%# TODO: add authorization_handler field %>
+
+      <%= label_tag :file, t(".file") %>
+      <%= file_field_tag :file %>
+      <%= submit_tag t(".submit"), class: "button" %>
+    <% end %>
+
+  </div>
+</div>
+
+<%= javascript_include_tag "decidim/direct_verifications/verification/admin/direct_verifications_admin" %>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -9,8 +9,11 @@
   <div class="card-section">
     <p><%= t("decidim.direct_verifications.verification.admin.imports.new.info") %></p>
     <pre class="code-block">
-      <strong><%= t("decidim.direct_verifications.verification.admin.imports.new.template.header") %></strong>
-      <%= t("decidim.direct_verifications.verification.admin.imports.new.template.body") %>
+      <strong>email, name, membership_phone, membership_type, membership_weight</strong>
+      ava@example.com, Ava Hawkins, +3476318371, consumer, 1
+      ewan@example.com, Ewan Cooper, +34653565765, worker, 1
+      tilly@example.com, Tilly Jones, +34653565761, collaborator, 0.67
+      ...
     </pre>
 
     <%= decidim_form_for(@form, url: imports_path, html: { class: "form" }) do |form| %>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -13,7 +13,6 @@
     </pre>
 
     <%= decidim_form_for(@form, url: imports_path, html: { class: "form" }) do |form| %>
-      <%= label_tag :userslist, t("admin.new.textarea", scope: "decidim.direct_verifications.verification") %>
       <label>
         <%= check_box_tag :register %>
         <%= t("admin.new.register", scope: "decidim.direct_verifications.verification") %>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -11,7 +11,8 @@
     <pre class="code-block">
     foo
     </pre>
-    <%= form_tag imports_path, multipart: true, class: "form" do %>
+
+    <%= decidim_form_for(@form, url: imports_path, html: { class: "form" }) do |form| %>
       <%= label_tag :userslist, t("admin.new.textarea", scope: "decidim.direct_verifications.verification") %>
       <label>
         <%= check_box_tag :register %>
@@ -35,9 +36,8 @@
 
       <%# TODO: add authorization_handler field %>
 
-      <%= label_tag :file, t(".file") %>
-      <%= file_field_tag :file %>
-      <%= submit_tag t(".submit"), class: "button" %>
+      <%= form.file_field :file, label: t(".file") %>
+      <%= form.submit t(".submit"), class: "button" %>
     <% end %>
 
   </div>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -37,7 +37,8 @@
         <%= t("admin.new.check", scope: "decidim.direct_verifications.verification") %>
       </label>
 
-      <%# TODO: add authorization_handler field %>
+      <%= label_tag :authorization_handler, t("admin.new.authorization_handler", scope: "decidim.direct_verifications.verification") %>
+      <%= select_tag :authorization_handler, options_for_select(workflows, current_authorization_handler) %>
 
       <%= form.file_field :file, label: t(".file") %>
       <%= form.submit t(".submit"), class: "button" %>

--- a/config/initializers/mail_previews.rb
+++ b/config/initializers/mail_previews.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.action_mailer.preview_path = Decidim::DirectVerifications::Verification::Engine.root.join("spec/mailers")
+end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -32,6 +32,7 @@ ca:
             create:
               authorized: "S'han verificat correctament %{authorized} usuaris utilitzant [%{handler}] (%{count} detectats, %{errors} errors)"
               info: "S'han detectat %{count} usuaris, dels quals %{registered} estan registrats, %{authorized} autoritzats utilitzant [%{handler}] (%{unconfirmed} sense confirmar)"
+              missing_header: Si us plau, proporcioneu una fila d'encapçalament
               registered: "S'han registrat correctament %{registered} usuaris (%{count} detectats, %{errors} errors)"
               revoked: S'ha revocat correctament la verificació de %{revoked} usuaris utilitzant [%{handler}] (%{count} detectats, %{errors} errors)
             gdpr_disclaimer: Feu-ho sota la vostra responsabilitat. Recordeu que heu de tenir el consentiment explícit dels vostres usuaris per registrar-los. En cas contrari, estareu infringint la regulació GDPR als països de la UE.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,13 +24,6 @@ en:
           imports:
             new:
               info: Import a CSV file with a user entry per line copying the format from the example below
-              template:
-                header: email, name, membership_phone, membership_type, membership_weight
-                body: |
-                  ava@example.com, Ava Hawkins, +3476318371, consumer, 1
-                  ewan@example.com, Ewan Cooper, +34653565765, worker, 1
-                  tilly@example.com, Tilly Jones, +34653565761, collaborator, 0.67
-                  ...
               submit: Upload file
               file: CSV file with users data
             create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,14 @@ en:
         admin:
           imports:
             new:
+              info: Import a CSV file with a user entry per line copying the format from the example below
+              template:
+                header: email, name, membership_phone, membership_type, membership_weight
+                body: |
+                  ava@example.com, Ava Hawkins, +3476318371, consumer, 1
+                  ewan@example.com, Ewan Cooper, +34653565765, worker, 1
+                  tilly@example.com, Tilly Jones, +34653565761, collaborator, 0.67
+                  ...
               submit: Upload file
               file: CSV file with users data
             create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
               file: CSV file with users data
             create:
               success: successfully
+              error: There was an error importing the file
             successful_import:
               subject: File imported successfully
           authorizations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,14 @@ en:
               error: There was an error importing the file
             mailer:
               subject: Users processed
+              authorized: "%{successful} users have been successfully verified using
+                [%{handler}] (%{count} detected, %{errors} errors)"
+              info: "%{count} users detected, of which %{registered} are registered,
+                %{authorized} authorized using [%{handler}] (%{unconfirmed} unconfirmed)"
+              registered: "%{successful} users have been successfully registered (%{count}
+                detected, %{errors} errors) "
+              revoked: Verification from %{successful} users have been revoked using
+                [%{handler}] (%{count} detected, %{errors} errors)
           authorizations:
             index:
               created_at: Created at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
               success: File successfully uploaded. We'll email you when all users are imported.
               error: There was an error importing the file
             mailer:
-              subject: Users processed
+              subject: File import results
               authorized: "%{successful} users have been successfully verified using
                 [%{handler}] (%{count} detected, %{errors} errors)"
               info: "%{count} users detected, of which %{registered} are registered,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,8 @@ en:
               file: CSV file with users data
             create:
               success: successfully
+            successful_import:
+              subject: File imported successfully
           authorizations:
             index:
               created_at: Created at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,12 @@ en:
     direct_verifications:
       verification:
         admin:
+          imports:
+            new:
+              submit: Upload file
+              file: CSV file with users data
+            create:
+              success: successfully
           authorizations:
             index:
               created_at: Created at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,8 +68,7 @@ en:
             authorization_handler: Verification method
             authorize: Authorize users
             check: Check users status
-            info: Enter the emails here, one per line. If the emails are preceded
-              by a text, it will be interpreted as the user's name
+            info_html: You can <a href=%{link}>import a CSV</a> or enter the emails here, one per line. If the emails are preceded by a text, it will be interpreted as the user's name.
             register: Register users in the platform (if they exist they will be ignored)
             revoke: Revoke authorization from users
             submit: Send and process the list

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
                 [%{handler}] (%{count} detected, %{errors} errors)"
               info: "%{count} users detected, of which %{registered} are registered,
                 %{authorized} authorized using [%{handler}] (%{unconfirmed} unconfirmed)"
+              missing_header: Please, provide a header row
               registered: "%{registered} users have been successfully registered (%{count}
                 detected, %{errors} errors) "
               revoked: Verification from %{revoked} users have been revoked using

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
               submit: Upload file
               file: CSV file with users data
             create:
-              success: successfully
+              success: File successfully uploaded. We'll email you when all users are imported.
               error: There was an error importing the file
             mailer:
               subject: Users processed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,8 +28,8 @@ en:
             create:
               success: successfully
               error: There was an error importing the file
-            successful_import:
-              subject: File imported successfully
+            mailer:
+              subject: Users processed
           authorizations:
             index:
               created_at: Created at

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -32,6 +32,7 @@ es:
             create:
               authorized: "Se han verificado correctamente %{authorized} usuarios usando [%{handler}] (%{count} detectados, %{errors} errores)"
               info: "Se han detectado %{count} usuarios, de los cuales %{registered} están registrados, %{authorized} autorizados usando [%{handler}] (%{unconfirmed} sin confirmar)"
+              missing_header: Por favor, proporcionad una fila de encabezamiento
               registered: "Se han registrado correctamente %{registered} usuarios (%{count} detectados, %{errors} errores)"
               revoked: Se ha revocado correctament la verificación de %{revoked} usuarios usando [%{handler}] (%{count} detectados, %{errors} errores)
             gdpr_disclaimer: Haga esto bajo su responsabilidad. Recuerde que debe contar con el consentimiento explícito de sus usuarios para poder registrarlos. De lo contrario, estará infringiendo la regulación GDPR en los países de la UE.

--- a/lib/decidim/direct_verifications/authorize_user.rb
+++ b/lib/decidim/direct_verifications/authorize_user.rb
@@ -3,13 +3,16 @@
 module Decidim
   module DirectVerifications
     class AuthorizeUser
-      def initialize(email, data, session, organization, instrumenter)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(email, data, session, organization, instrumenter, authorization_handler)
         @email = email
         @data = data
         @session = session
         @organization = organization
         @instrumenter = instrumenter
+        @authorization_handler = authorization_handler
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def call
         unless user
@@ -31,7 +34,7 @@ module Decidim
 
       private
 
-      attr_reader :email, :data, :session, :organization, :instrumenter
+      attr_reader :email, :data, :session, :organization, :instrumenter, :authorization_handler
 
       def valid_authorization?
         !authorization.granted? || authorization.expired?
@@ -46,7 +49,7 @@ module Decidim
           begin
             auth = Authorization.find_or_initialize_by(
               user: user,
-              name: :direct_verifications
+              name: authorization_handler
             )
             auth.metadata = data
             auth

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -5,8 +5,8 @@ module Decidim
     class Instrumenter
       def initialize(current_user)
         @current_user = current_user
-        @errors = { registered: [], authorized: [], revoked: [] }
-        @processed = { registered: [], authorized: [], revoked: [] }
+        @errors = { registered: Set.new, authorized: Set.new, revoked: Set.new }
+        @processed = { registered: Set.new, authorized: Set.new, revoked: Set.new }
       end
 
       def processed_count(key)
@@ -27,11 +27,11 @@ module Decidim
       end
 
       def add_error(type, email)
-        @errors[type] << email unless @errors[type].include? email
+        @errors[type] << email
       end
 
       def add_processed(type, email)
-        @processed[type] << email unless @processed[type].include? email
+        @processed[type] << email
       end
 
       private

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -25,6 +25,10 @@ module Decidim
         errors[key].size
       end
 
+      def emails_count(key)
+        @processed[key].size + @errors[key].size
+      end
+
       def track(event, email, user = nil)
         if user
           add_processed event, email

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -3,12 +3,18 @@
 module Decidim
   module DirectVerifications
     class Instrumenter
-      attr_reader :processed, :errors
-
       def initialize(current_user)
         @current_user = current_user
         @errors = { registered: [], authorized: [], revoked: [] }
         @processed = { registered: [], authorized: [], revoked: [] }
+      end
+
+      def processed_count(key)
+        processed[key].size
+      end
+
+      def errors_count(key)
+        errors[key].size
       end
 
       def track(event, email, user = nil)
@@ -30,7 +36,7 @@ module Decidim
 
       private
 
-      attr_reader :current_user
+      attr_reader :current_user, :processed, :errors
 
       def log_action(user)
         Decidim.traceability.perform_action!(

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -9,6 +9,14 @@ module Decidim
         @processed = { registered: Set.new, authorized: Set.new, revoked: Set.new }
       end
 
+      def add_processed(type, email)
+        @processed[type] << email
+      end
+
+      def add_error(type, email)
+        @errors[type] << email
+      end
+
       def processed_count(key)
         processed[key].size
       end
@@ -24,14 +32,6 @@ module Decidim
         else
           add_error event, email
         end
-      end
-
-      def add_error(type, email)
-        @errors[type] << email
-      end
-
-      def add_processed(type, email)
-        @processed[type] << email
       end
 
       private

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class Instrumenter
+      attr_reader :processed, :errors
+
+      def initialize(current_user)
+        @current_user = current_user
+        @errors = { registered: [], authorized: [], revoked: [] }
+        @processed = { registered: [], authorized: [], revoked: [] }
+      end
+
+      def track(event, email, user = nil)
+        if user
+          add_processed event, email
+          log_action user
+        else
+          add_error event, email
+        end
+      end
+
+      def add_error(type, email)
+        @errors[type] << email unless @errors[type].include? email
+      end
+
+      def add_processed(type, email)
+        @processed[type] << email unless @processed[type].include? email
+      end
+
+      private
+
+      attr_reader :current_user
+
+      def log_action(user)
+        Decidim.traceability.perform_action!(
+          "invite",
+          user,
+          current_user,
+          extra: {
+            invited_user_role: "participant",
+            invited_user_id: user.id
+          }
+        )
+      end
+    end
+  end
+end

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -12,11 +12,11 @@ module Decidim
       end
 
       def call
-        return if find_user
+        return if user
 
         InviteUser.call(form) do
           on(:ok) do
-            instrumenter.track(:registered, email, find_user)
+            instrumenter.track(:registered, email, user)
           end
           on(:invalid) do
             instrumenter.track(:registered, email)
@@ -31,8 +31,8 @@ module Decidim
 
       attr_reader :email, :name, :organization, :current_user, :instrumenter
 
-      def find_user
-        User.find_by(email: email, decidim_organization_id: organization.id)
+      def user
+        @user ||= User.find_by(email: email, decidim_organization_id: organization.id)
       end
 
       def form

--- a/lib/decidim/direct_verifications/register_user.rb
+++ b/lib/decidim/direct_verifications/register_user.rb
@@ -3,9 +3,9 @@
 module Decidim
   module DirectVerifications
     class RegisterUser
-      def initialize(email, name, organization, current_user, instrumenter)
+      def initialize(email, data, organization, current_user, instrumenter)
         @email = email
-        @name = name
+        @name = data.is_a?(Hash) ? data[:name] : data
         @organization = organization
         @current_user = current_user
         @instrumenter = instrumenter

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -3,10 +3,11 @@
 module Decidim
   module DirectVerifications
     class RevokeUser
-      def initialize(email, organization, instrumenter)
+      def initialize(email, organization, instrumenter, authorization_handler = :direct_verifications)
         @email = email
         @organization = organization
         @instrumenter = instrumenter
+        @authorization_handler = authorization_handler
       end
 
       def call
@@ -26,14 +27,14 @@ module Decidim
 
       private
 
-      attr_reader :email, :organization, :instrumenter
+      attr_reader :email, :organization, :instrumenter, :authorization_handler
 
       def user
         @user ||= User.find_by(email: email, decidim_organization_id: organization.id)
       end
 
       def authorization
-        @authorization ||= Authorization.find_by(user: user, name: :direct_verifications)
+        @authorization ||= Authorization.find_by(user: user, name: authorization_handler)
       end
 
       def valid_authorization?

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -15,7 +15,7 @@ module Decidim
           return
         end
 
-        return unless authorization.granted?
+        return unless valid_authorization?
 
         Verification::DestroyUserAuthorization.call(authorization) do
           on(:ok) do
@@ -36,10 +36,11 @@ module Decidim
       end
 
       def authorization
-        @authorization ||= Authorization.find_or_initialize_by(
-          user: user,
-          name: :direct_verifications
-        )
+        @authorization ||= Authorization.find_by(user: user, name: :direct_verifications)
+      end
+
+      def valid_authorization?
+        authorization&.granted?
       end
     end
   end

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -21,9 +21,6 @@ module Decidim
           on(:ok) do
             instrumenter.add_processed :revoked, email
           end
-          on(:invalid) do
-            add_error :revoked, email
-          end
         end
       end
 

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class RevokeUser
+      def initialize(email, organization, instrumenter)
+        @email = email
+        @organization = organization
+        @instrumenter = instrumenter
+      end
+
+      def call
+        if (u = find_user)
+          auth = authorization(u)
+          return unless auth.granted?
+
+          Verification::DestroyUserAuthorization.call(auth) do
+            on(:ok) do
+              instrumenter.add_processed :revoked, email
+            end
+            on(:invalid) do
+              add_error :revoked, email
+            end
+          end
+        else
+          instrumenter.add_error :revoked, email
+        end
+      end
+
+      private
+
+      attr_reader :email, :organization, :instrumenter
+
+      def find_user
+        User.find_by(email: email, decidim_organization_id: organization.id)
+      end
+
+      def authorization(user)
+        Authorization.find_or_initialize_by(
+          user: user,
+          name: :direct_verifications
+        )
+      end
+    end
+  end
+end

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -3,7 +3,7 @@
 module Decidim
   module DirectVerifications
     class RevokeUser
-      def initialize(email, organization, instrumenter, authorization_handler = :direct_verifications)
+      def initialize(email, organization, instrumenter, authorization_handler)
         @email = email
         @organization = organization
         @instrumenter = instrumenter

--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -23,12 +23,7 @@ module Decidim
 
       def register_users
         emails.each do |email, data|
-          name = if data.is_a?(Hash)
-                   data[:name]
-                 else
-                   data
-                 end
-          RegisterUser.new(email, name, organization, current_user, instrumenter).call
+          RegisterUser.new(email, data, organization, current_user, instrumenter).call
         end
       end
 

--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -35,7 +35,7 @@ module Decidim
 
       def revoke_users
         emails.each do |email, _name|
-          RevokeUser.new(email, organization, instrumenter).call
+          RevokeUser.new(email, organization, instrumenter, authorization_handler).call
         end
       end
 

--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -29,7 +29,7 @@ module Decidim
 
       def authorize_users
         emails.each do |email, data|
-          AuthorizeUser.new(email, data, session, organization, instrumenter).call
+          AuthorizeUser.new(email, data, session, organization, instrumenter, authorization_handler).call
         end
       end
 

--- a/lib/decidim/direct_verifications/verification/admin_engine.rb
+++ b/lib/decidim/direct_verifications/verification/admin_engine.rb
@@ -11,6 +11,7 @@ module Decidim
           resources :direct_verifications, only: [:index, :create, :stats]
           resources :stats, only: [:index]
           resources :authorizations, only: [:index, :destroy]
+          resources :imports, only: [:new, :create]
 
           root to: "direct_verifications#index"
         end

--- a/spec/commands/decidim/direct_verifications/verification/create_import_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/create_import_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    module Verification
+      describe CreateImport do
+        subject(:command) { described_class.new(form) }
+
+        let(:form) do
+          instance_double(CreateImportForm, file: file, organization: organization, user: user)
+        end
+        let(:filename) { file_fixture("users.csv") }
+        let(:file) { Rack::Test::UploadedFile.new(filename, "text/csv") }
+        let(:organization) { build(:organization) }
+        let(:user) { build(:user) }
+
+        before do
+          allow(RegisterUsersJob).to receive(:perform_later)
+        end
+
+        context "when the form is valid" do
+          before do
+            allow(form).to receive(:valid?).and_return(true)
+          end
+
+          it "calls the RegisterUsersJob job" do
+            command.call
+            expect(RegisterUsersJob).to have_received(:perform_later)
+          end
+
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+        end
+
+        context "when the form is not valid" do
+          before do
+            allow(form).to receive(:valid?).and_return(false)
+          end
+
+          it "does not call the RegisterUsersJob job" do
+            command.call
+            expect(RegisterUsersJob).not_to have_received(:perform_later)
+          end
+
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/direct_verifications/verification/create_import_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/create_import_spec.rb
@@ -9,7 +9,14 @@ module Decidim
         subject(:command) { described_class.new(form) }
 
         let(:form) do
-          instance_double(CreateImportForm, file: file, organization: organization, user: user, action: action)
+          instance_double(
+            CreateImportForm,
+            file: file,
+            organization: organization,
+            user: user,
+            action: action,
+            authorization_handler: "direct_verifications"
+          )
         end
         let(:filename) { file_fixture("users.csv") }
         let(:file) { Rack::Test::UploadedFile.new(filename, "text/csv") }

--- a/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
@@ -29,6 +29,21 @@ module Decidim::DirectVerifications::Verification
         end
       end
 
+      context "when the text has empty columns" do
+        let(:txt) do
+          <<-EMAILS.strip_heredoc
+            Name,Email,Department,Salary
+            Bob,bob@example.com,,1000
+          EMAILS
+        end
+
+        it "skips those columns" do
+          expect(subject.to_h).to eq(
+            "bob@example.com" => { name: "Bob", salary: "1000" }
+          )
+        end
+      end
+
       context "when the text is a CSV with headers" do
         let(:txt) do
           <<-ROWS.strip_heredoc

--- a/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
@@ -6,6 +6,16 @@ module Decidim::DirectVerifications::Verification
   describe MetadataParser do
     subject { described_class.new(txt) }
 
+    describe "#header" do
+      context "when the first line has empty columns" do
+        let(:txt) { "Melina.morrison@bccm.coop,MORRISON Melina,,,11" }
+
+        it "raises an error" do
+          expect { subject.to_h }.to raise_error(MissingHeaderError)
+        end
+      end
+    end
+
     describe "#to_h" do
       context "when the text is empty" do
         let(:txt) { "" }

--- a/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
@@ -39,7 +39,7 @@ module Decidim::DirectVerifications::Verification
 
         it "skips those columns" do
           expect(subject.to_h).to eq(
-            "bob@example.com" => { name: "Bob", salary: "1000" }
+            "bob@example.com" => { department: nil, name: "Bob", salary: "1000" }
           )
         end
       end

--- a/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
@@ -68,6 +68,21 @@ module Decidim::DirectVerifications::Verification
           end
         end
 
+        context "and the CSV includes trailing or leading whitespaces" do
+          let(:txt) do
+            <<-CSV.strip_heredoc
+            Name, Email, Type
+            Ava Hawkins, ava@example.com, collaborator
+            CSV
+          end
+
+          it "returns the data in a hash with the email as key" do
+            expect(subject.to_h).to eq(
+              "ava@example.com" => { name: "Ava Hawkins", type: "collaborator" }
+            )
+          end
+        end
+
         context "when the name is not specified" do
           let(:txt) do
             <<-EMAILS.strip_heredoc

--- a/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
@@ -113,6 +113,20 @@ module Decidim::DirectVerifications::Verification::Admin
             expect(authorization.metadata).to eq("name" => "Brandy", "type" => "consumer")
           end
 
+          context "when a column is empty" do
+            it "sets it nil" do
+              post :create, params: {
+                userslist: "Name,Email,Type,City\r\nBrandy,brandy@example.com,,Barcelona",
+                register: true,
+                authorize: "in"
+              }
+
+              user = Decidim::User.find_by(email: "brandy@example.com")
+              authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
+              expect(authorization.metadata).to eq("name" => "Brandy", "type" => nil, "city" => "Barcelona")
+            end
+          end
+
           context "when the name is not specified" do
             it "infers the name from the email" do
               post :create, params: {

--- a/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
@@ -163,8 +163,15 @@ module Decidim::DirectVerifications::Verification::Admin
         end
       end
 
-      context "when register users with revoke" do
+      context "when revoking users" do
         params = { userslist: "authorized@example.com", authorize: "out" }
+        it_behaves_like "revoking users", params
+      end
+
+      context "when revoking users with another verification" do
+        params = { userslist: "authorized@example.com", authorize: "out", authorization_handler: "other" }
+        let(:verification_type) { "other" }
+
         it_behaves_like "revoking users", params
       end
     end

--- a/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
@@ -14,6 +14,8 @@ module Decidim::DirectVerifications::Verification::Admin
     let(:verification_type) { "direct_verifications" }
     let(:authorized_user) { create(:user, email: "authorized@example.com", organization: organization) }
 
+    let(:i18n_scope) { "decidim.direct_verifications.verification.admin.direct_verifications" }
+
     before do
       request.env["decidim.current_organization"] = user.organization
       sign_in user, scope: :user
@@ -138,6 +140,24 @@ module Decidim::DirectVerifications::Verification::Admin
 
               user = Decidim::User.find_by(email: "brandy@example.com")
               expect(user.name).to eq("brandy")
+            end
+          end
+
+          context "when the first row has empty columns" do
+            let(:data) { "brandy@example.com,,consumer" }
+
+            it "shows a user error" do
+              post :create, params: { userslist: data, register: true, authorize: "in" }
+              expect(flash[:error]).to eq(I18n.t("#{i18n_scope}.create.missing_header"))
+            end
+          end
+
+          context "when no header is provided" do
+            let(:data) { "brandy@example.com,consumer" }
+
+            it "works" do
+              post :create, params: { userslist: data, register: true, authorize: "in" }
+              expect(response).to redirect_to(direct_verifications_path)
             end
           end
         end

--- a/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
@@ -32,10 +32,13 @@ module Decidim::DirectVerifications::Verification::Admin
     describe "POST create" do
       context "when parameters are defaults" do
         params = { userslist: "" }
+
         it_behaves_like "checking users", params
+
         it "have no registered or authorized users" do
           perform_enqueued_jobs do
             post :create, params: params
+
             expect(flash[:info]).to include("0 are registered")
             expect(flash[:info]).to include("0 authorized")
             expect(flash[:info]).to include("unconfirmed")
@@ -62,7 +65,9 @@ module Decidim::DirectVerifications::Verification::Admin
         it "renders the index with warning message" do
           perform_enqueued_jobs do
             post :create, params: params
-            expect(subject).to render_template("decidim/direct_verifications/verification/admin/direct_verifications/index")
+            expect(subject).to render_template(
+              "decidim/direct_verifications/verification/admin/direct_verifications/index"
+            )
           end
         end
       end
@@ -81,12 +86,10 @@ module Decidim::DirectVerifications::Verification::Admin
         end
 
         context "when the name is not specified" do
+          let(:data) { "Name,Email,Type\r\n\"\",brandy@example.com,consumer" }
+
           it "infers the name from the email" do
-            post :create, params: {
-              userslist: "Name,Email,Type\r\n\"\",brandy@example.com,consumer",
-              register: true,
-              authorize: "in"
-            }
+            post :create, params: { userslist: data, register: true, authorize: "in" }
 
             user = Decidim::User.find_by(email: "brandy@example.com")
             expect(user.name).to eq("brandy")
@@ -94,6 +97,10 @@ module Decidim::DirectVerifications::Verification::Admin
         end
 
         context "when in metadata mode" do
+          let(:data) do
+            "Name,Email,Type\r\nBrandy,brandy@example.com,consumer,2\r\nWhisky,whisky@example.com,producer,3"
+          end
+
           around do |example|
             original_processor = Rails.configuration.direct_verifications_parser
             Rails.configuration.direct_verifications_parser = :metadata
@@ -102,11 +109,7 @@ module Decidim::DirectVerifications::Verification::Admin
           end
 
           it "stores any extra columns as authorization metadata" do
-            post :create, params: {
-              userslist: "Name,Email,Type\r\nBrandy,brandy@example.com,consumer,2\r\nWhisky,whisky@example.com,producer,3",
-              register: true,
-              authorize: "in"
-            }
+            post :create, params: { userslist: data, register: true, authorize: "in" }
 
             user = Decidim::User.find_by(email: "brandy@example.com")
             authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
@@ -114,26 +117,24 @@ module Decidim::DirectVerifications::Verification::Admin
           end
 
           context "when a column is empty" do
+            let(:data) { "Name,Email,Type,City\r\nBrandy,brandy@example.com,,Barcelona" }
+
             it "sets it nil" do
-              post :create, params: {
-                userslist: "Name,Email,Type,City\r\nBrandy,brandy@example.com,,Barcelona",
-                register: true,
-                authorize: "in"
-              }
+              post :create, params: { userslist: data, register: true, authorize: "in" }
 
               user = Decidim::User.find_by(email: "brandy@example.com")
               authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
-              expect(authorization.metadata).to eq("name" => "Brandy", "type" => nil, "city" => "Barcelona")
+
+              expect(authorization.metadata)
+                .to eq("name" => "Brandy", "type" => nil, "city" => "Barcelona")
             end
           end
 
           context "when the name is not specified" do
+            let(:data) { "Name,Email,Type\r\n\"\",brandy@example.com,consumer" }
+
             it "infers the name from the email" do
-              post :create, params: {
-                userslist: "Name,Email,Type\r\n\"\",brandy@example.com,consumer",
-                register: true,
-                authorize: "in"
-              }
+              post :create, params: { userslist: data, register: true, authorize: "in" }
 
               user = Decidim::User.find_by(email: "brandy@example.com")
               expect(user.name).to eq("brandy")

--- a/spec/controllers/decidim/direct_verifications/verification/admin/imports_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/imports_controller_spec.rb
@@ -19,6 +19,11 @@ module Decidim::DirectVerifications::Verification::Admin
         expect(controller).to receive(:allowed_to?).with(:create, :authorization, {})
         get :new
       end
+
+      it "renders the decidim/admin/users layout" do
+        get :new
+        expect(response).to render_template("layouts/decidim/admin/users")
+      end
     end
 
     describe "#create" do

--- a/spec/controllers/decidim/direct_verifications/verification/admin/imports_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/imports_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::DirectVerifications::Verification::Admin
+  describe ImportsController, type: :controller do
+    routes { Decidim::DirectVerifications::Verification::AdminEngine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      sign_in user
+    end
+
+    describe "#new" do
+      it "authorizes the action" do
+        expect(controller).to receive(:allowed_to?).with(:create, :authorization, {})
+        get :new
+      end
+    end
+
+    describe "#create" do
+      let(:filename) { "fixture.csv" }
+      let(:file) { Rack::Test::UploadedFile.new(filename, "text/csv") }
+
+      before do
+        CSV.open(filename, "wb") do |csv|
+          csv << %w(Name Email Type)
+          csv << %w(Brandy brandy@example.com consumer)
+        end
+      end
+
+      it "authorizes the action" do
+        expect(controller).to receive(:allowed_to?).with(:create, :authorization, {})
+        post :create, params: { file: file }
+      end
+    end
+  end
+end

--- a/spec/controllers/decidim/direct_verifications/verification/admin/imports_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/imports_controller_spec.rb
@@ -22,15 +22,8 @@ module Decidim::DirectVerifications::Verification::Admin
     end
 
     describe "#create" do
-      let(:filename) { "fixture.csv" }
+      let(:filename) { file_fixture("users.csv") }
       let(:file) { Rack::Test::UploadedFile.new(filename, "text/csv") }
-
-      before do
-        CSV.open(filename, "wb") do |csv|
-          csv << %w(Name Email Type)
-          csv << %w(Brandy brandy@example.com consumer)
-        end
-      end
 
       context "when the import is valid" do
         it "authorizes the action" do

--- a/spec/controllers/decidim/direct_verifications/verification/admin/imports_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/imports_controller_spec.rb
@@ -32,9 +32,33 @@ module Decidim::DirectVerifications::Verification::Admin
         end
       end
 
-      it "authorizes the action" do
-        expect(controller).to receive(:allowed_to?).with(:create, :authorization, {})
-        post :create, params: { file: file }
+      context "when the import is valid" do
+        it "authorizes the action" do
+          expect(controller).to receive(:allowed_to?).with(:create, :authorization, {})
+          post :create, params: { file: file }
+        end
+
+        it "redirects to :new" do
+          post :create, params: { file: file }
+          expect(response).to redirect_to(new_import_path)
+        end
+      end
+
+      context "when the import is not valid" do
+        it "authorizes the action" do
+          expect(controller).to receive(:allowed_to?).with(:create, :authorization, {})
+          post :create, params: {}
+        end
+
+        it "redirects to :new" do
+          post :create, params: {}
+          expect(response).to redirect_to(new_import_path)
+        end
+
+        it "displays an error" do
+          post :create, params: {}
+          expect(flash[:alert]).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.create.error"))
+        end
       end
     end
   end

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -1,0 +1,2 @@
+Name,Email,Type
+Brandy,brandy@example.com,consumer

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -1,2 +1,2 @@
-Name,Email,Type
-Brandy,brandy@example.com,consumer
+Name, Email, Type
+Brandy, brandy@example.com, consumer

--- a/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
+++ b/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    module Verification
+      describe CreateImportForm do
+        subject(:form) { described_class.from_params(attributes) }
+
+        let(:attributes) do
+          {
+            user: build(:user),
+            organization: build(:organization),
+            file: double(File),
+            authorize: action
+          }
+        end
+        let(:action) { "in" }
+
+        context "when all attributes are provided" do
+          it { is_expected.to be_valid }
+        end
+
+        context "when action is in" do
+          let(:action) { "in" }
+
+          it "returns it as :register" do
+            expect(form.action).to eq(:register)
+          end
+        end
+
+        context "when action is out" do
+          let(:action) { "out" }
+
+          it "returns it as :revoke" do
+            expect(form.action).to eq(:revoke)
+          end
+        end
+
+        context "when action is check" do
+          let(:action) { "check" }
+
+          it "returns it as :check" do
+            expect(form.action).to eq(:check)
+          end
+        end
+
+        context "when action is unknown" do
+          let(:action) { "dummy" }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
+++ b/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
@@ -22,34 +22,87 @@ module Decidim
           it { is_expected.to be_valid }
         end
 
-        context "when action is in" do
-          let(:action) { "in" }
+        context "when :register is provided" do
+          let(:attributes) do
+            {
+              user: build(:user),
+              organization: build(:organization),
+              file: double(File),
+              authorize: action,
+              register: "1"
+            }
+          end
 
-          it "returns it as :register" do
-            expect(form.action).to eq(:register)
+          context "when action is in" do
+            let(:action) { "in" }
+
+            it "returns it as :register_and_authorize" do
+              expect(form.action).to eq(:register_and_authorize)
+            end
+          end
+
+          context "when action is out" do
+            let(:action) { "out" }
+
+            it "returns it as :register" do
+              expect(form.action).to eq(:register)
+            end
+          end
+
+          context "when action is check" do
+            let(:action) { "check" }
+
+            it "returns it as :register" do
+              expect(form.action).to eq(:register)
+            end
+          end
+
+          context "when action is unknown" do
+            let(:action) { "dummy" }
+
+            it { is_expected.not_to be_valid }
           end
         end
 
-        context "when action is out" do
-          let(:action) { "out" }
-
-          it "returns it as :revoke" do
-            expect(form.action).to eq(:revoke)
+        context "when :register is not provided" do
+          let(:attributes) do
+            {
+              user: build(:user),
+              organization: build(:organization),
+              file: double(File),
+              authorize: action
+            }
           end
-        end
 
-        context "when action is check" do
-          let(:action) { "check" }
+          context "when action is in" do
+            let(:action) { "in" }
 
-          it "returns it as :check" do
-            expect(form.action).to eq(:check)
+            it "returns it as :authorize" do
+              expect(form.action).to eq(:authorize)
+            end
           end
-        end
 
-        context "when action is unknown" do
-          let(:action) { "dummy" }
+          context "when action is out" do
+            let(:action) { "out" }
 
-          it { is_expected.not_to be_valid }
+            it "returns it as :revoke" do
+              expect(form.action).to eq(:revoke)
+            end
+          end
+
+          context "when action is check" do
+            let(:action) { "check" }
+
+            it "returns it as :check" do
+              expect(form.action).to eq(:check)
+            end
+          end
+
+          context "when action is unknown" do
+            let(:action) { "dummy" }
+
+            it { is_expected.not_to be_valid }
+          end
         end
       end
     end

--- a/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
+++ b/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
@@ -8,12 +8,14 @@ module Decidim
       describe CreateImportForm do
         subject(:form) { described_class.from_params(attributes) }
 
+        let(:organization) { build(:organization, available_authorizations: %w(direct_verifications)) }
         let(:attributes) do
           {
             user: build(:user),
-            organization: build(:organization),
+            organization: organization,
             file: double(File),
-            authorize: action
+            authorize: action,
+            authorization_handler: "direct_verifications"
           }
         end
         let(:action) { "in" }
@@ -103,6 +105,33 @@ module Decidim
 
             it { is_expected.not_to be_valid }
           end
+        end
+
+        context "when authorization handler is not provided" do
+          let(:attributes) do
+            {
+              user: build(:user),
+              organization: build(:organization),
+              file: double(File),
+              authorize: action
+            }
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when authorization handler is not known" do
+          let(:attributes) do
+            {
+              user: build(:user),
+              organization: build(:organization),
+              file: double(File),
+              authorize: action,
+              authorization_handler: "unknown"
+            }
+          end
+
+          it { is_expected.not_to be_valid }
         end
       end
     end

--- a/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
@@ -15,7 +15,10 @@ module Decidim
       end
 
       before do
-        allow(ImportMailer).to receive(:successful_import).with(current_user).and_return(mailer)
+        allow(ImportMailer)
+          .to receive(:finished_registration)
+          .with(current_user, kind_of(Instrumenter))
+          .and_return(mailer)
       end
 
       it "creates the user" do

--- a/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
@@ -17,7 +17,7 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :registered)
+          .with(current_user, kind_of(Instrumenter), :registered, :direct_verifications)
           .and_return(mailer)
       end
 

--- a/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
@@ -17,12 +17,12 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :registered, :direct_verifications)
+          .with(current_user, kind_of(Instrumenter), :registered, "direct_verifications")
           .and_return(mailer)
       end
 
       it "creates the user" do
-        expect { described_class.perform_later(userslist, organization, current_user) }
+        expect { described_class.perform_later(userslist, organization, current_user, "direct_verifications") }
           .to change(Decidim::User, :count).from(1).to(2)
 
         user = Decidim::User.find_by(email: "brandy@example.com")
@@ -30,7 +30,7 @@ module Decidim
       end
 
       it "does not authorize the user" do
-        described_class.perform_later(userslist, organization, current_user)
+        described_class.perform_later(userslist, organization, current_user, "direct_verifications")
 
         user = Decidim::User.find_by(email: "brandy@example.com")
         authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
@@ -38,7 +38,7 @@ module Decidim
       end
 
       it "notifies the result by email" do
-        described_class.perform_later(userslist, organization, current_user)
+        described_class.perform_later(userslist, organization, current_user, "direct_verifications")
         expect(mailer).to have_received(:deliver_now)
       end
     end

--- a/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe RegisterUsersJob, type: :job do
+      let(:userslist) { "Name,Email,Type\r\n\"\",brandy@example.com,consumer" }
+      let(:organization) { create(:organization) }
+      let!(:current_user) { create(:user, organization: organization) }
+      let(:mailer) { double(:mailer, deliver_now: true) }
+
+      around do |example|
+        perform_enqueued_jobs { example.run }
+      end
+
+      before do
+        allow(ImportMailer).to receive(:successful_import).with(current_user).and_return(mailer)
+      end
+
+      it "creates the user" do
+        expect { described_class.perform_later(userslist, organization, current_user) }
+          .to change(Decidim::User, :count).from(1).to(2)
+
+        user = Decidim::User.find_by(email: "brandy@example.com")
+        expect(user.name).to eq("brandy")
+      end
+
+      it "does not authorize the user" do
+        described_class.perform_later(userslist, organization, current_user)
+
+        user = Decidim::User.find_by(email: "brandy@example.com")
+        authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
+        expect(authorization).to be_nil
+      end
+
+      it "notifies the result by email" do
+        described_class.perform_later(userslist, organization, current_user)
+        expect(mailer).to have_received(:deliver_now)
+      end
+    end
+  end
+end

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -25,23 +25,13 @@ module Decidim
       end
 
       it "deletes the user authorization" do
-        Tempfile.create("import.csv") do |file|
-          file.write(userslist)
-          file.rewind
-
-          described_class.perform_later(file.path, organization, current_user)
-          expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
-        end
+        described_class.perform_later(userslist, organization, current_user)
+        expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
       end
 
       it "notifies the result by email" do
-        Tempfile.create("import.csv") do |file|
-          file.write(userslist)
-          file.rewind
-
-          described_class.perform_later(file.path, organization, current_user)
-          expect(mailer).to have_received(:deliver_now)
-        end
+        described_class.perform_later(userslist, organization, current_user)
+        expect(mailer).to have_received(:deliver_now)
       end
     end
   end

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -20,7 +20,7 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :revoked)
+          .with(current_user, kind_of(Instrumenter), :revoked, :direct_verifications)
           .and_return(mailer)
       end
 

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -20,17 +20,17 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :revoked, :direct_verifications)
+          .with(current_user, kind_of(Instrumenter), :revoked, "direct_verifications")
           .and_return(mailer)
       end
 
       it "deletes the user authorization" do
-        described_class.perform_later(userslist, organization, current_user)
+        described_class.perform_later(userslist, organization, current_user, "direct_verifications")
         expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
       end
 
       it "notifies the result by email" do
-        described_class.perform_later(userslist, organization, current_user)
+        described_class.perform_later(userslist, organization, current_user, "direct_verifications")
         expect(mailer).to have_received(:deliver_now)
       end
     end

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -4,11 +4,14 @@ require "spec_helper"
 
 module Decidim
   module DirectVerifications
-    describe RegisterUsersJob, type: :job do
+    describe RevokeUsersJob, type: :job do
       let(:userslist) { "Name,Email,Type\r\n\"\",brandy@example.com,consumer" }
       let(:organization) { create(:organization) }
-      let!(:current_user) { create(:user, organization: organization) }
+      let(:current_user) { create(:user, organization: organization) }
       let(:mailer) { double(:mailer, deliver_now: true) }
+
+      let(:user) { create(:user, organization: organization, email: "brandy@example.com") }
+      let!(:authorization) { create(:authorization, :granted, user: user, name: :direct_verifications) }
 
       around do |example|
         perform_enqueued_jobs { example.run }
@@ -17,24 +20,13 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :registered)
+          .with(current_user, kind_of(Instrumenter), :revoked)
           .and_return(mailer)
       end
 
-      it "creates the user" do
-        expect { described_class.perform_later(userslist, organization, current_user) }
-          .to change(Decidim::User, :count).from(1).to(2)
-
-        user = Decidim::User.find_by(email: "brandy@example.com")
-        expect(user.name).to eq("brandy")
-      end
-
-      it "does not authorize the user" do
+      it "deletes the user authorization" do
         described_class.perform_later(userslist, organization, current_user)
-
-        user = Decidim::User.find_by(email: "brandy@example.com")
-        authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
-        expect(authorization).to be_nil
+        expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
       end
 
       it "notifies the result by email" do

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -25,13 +25,23 @@ module Decidim
       end
 
       it "deletes the user authorization" do
-        described_class.perform_later(userslist, organization, current_user)
-        expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
+        Tempfile.create("import.csv") do |file|
+          file.write(userslist)
+          file.rewind
+
+          described_class.perform_later(file.path, organization, current_user)
+          expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
+        end
       end
 
       it "notifies the result by email" do
-        described_class.perform_later(userslist, organization, current_user)
-        expect(mailer).to have_received(:deliver_now)
+        Tempfile.create("import.csv") do |file|
+          file.write(userslist)
+          file.rewind
+
+          described_class.perform_later(file.path, organization, current_user)
+          expect(mailer).to have_received(:deliver_now)
+        end
       end
     end
   end

--- a/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
@@ -15,7 +15,7 @@ module Decidim
           let(:user) { create(:user, organization: organization) }
           let(:email) { user.email }
           let(:session) { {} }
-          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+          let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
           context "when passing the user name" do
             let(:data) { user.name }
@@ -108,7 +108,7 @@ module Decidim
           let(:email) { "em@mail.com" }
           let(:data) { "Andy" }
           let(:session) { {} }
-          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+          let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
           it "tracks an error" do
             subject.call

--- a/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
@@ -5,7 +5,11 @@ require "spec_helper"
 module Decidim
   module DirectVerifications
     describe AuthorizeUser do
-      subject { described_class.new(email, data, session, organization, instrumenter) }
+      subject do
+        described_class.new(email, data, session, organization, instrumenter, authorization_handler)
+      end
+
+      let(:authorization_handler) { :direct_verifications }
 
       describe "#call" do
         let(:data) { user.name }

--- a/spec/lib/decidim/direct_verifications/instrumenter_spec.rb
+++ b/spec/lib/decidim/direct_verifications/instrumenter_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe Instrumenter do
+      subject { described_class.new(current_user) }
+
+      let(:current_user) { build_stubbed(:user) }
+
+      shared_examples "an error event" do |type|
+        context "when the email does not exist" do
+          it "adds the email" do
+            subject.add_error(type, "email@example.com")
+            expect(subject.errors[type]).to contain_exactly("email@example.com")
+          end
+        end
+
+        context "when the email already exists" do
+          before { subject.add_error(type, "email@example.com") }
+
+          it "does not duplicate the email" do
+            subject.add_error(type, "email@example.com")
+            expect(subject.errors[type]).to contain_exactly("email@example.com")
+          end
+        end
+      end
+
+      shared_examples "a process event" do |type|
+        context "when the email does not exist" do
+          it "adds the email" do
+            subject.add_processed(type, "email@example.com")
+            expect(subject.processed[type]).to contain_exactly("email@example.com")
+          end
+        end
+
+        context "when the email already exists" do
+          before { subject.add_processed(type, "email@example.com") }
+
+          it "does not duplicate the email" do
+            subject.add_processed(type, "email@example.com")
+            expect(subject.processed[type]).to contain_exactly("email@example.com")
+          end
+        end
+      end
+
+      describe "#add_error" do
+        it_behaves_like "an error event", :registered
+        it_behaves_like "an error event", :authorized
+        it_behaves_like "an error event", :revoked
+
+        context "when the provided type does not exist" do
+          let(:type) { :fake }
+
+          it "raises due to NilClass" do
+            expect { subject.add_error(type, "email@example.com") }.to raise_error(NoMethodError)
+          end
+        end
+      end
+
+      describe "#add_processed" do
+        it_behaves_like "an error event", :registered
+        it_behaves_like "an error event", :authorized
+        it_behaves_like "an error event", :revoked
+
+        context "when the provided type does not exist" do
+          let(:type) { :fake }
+
+          it "raises due to NilClass" do
+            expect { subject.add_processed(type, "email@example.com") }.to raise_error(NoMethodError)
+          end
+        end
+      end
+
+      describe "#track" do
+        context "when a user is passed" do
+          let(:user) { build_stubbed(:user) }
+
+          before { allow(Decidim.traceability).to receive(:perform_action!) }
+
+          context "and the provided type exists" do
+            let(:type) { :registered }
+
+            it "adds the process event" do
+              subject.track(type, "email@example.com", user)
+              expect(subject.processed[type]).to contain_exactly("email@example.com")
+            end
+
+            it "logs the action" do
+              expect(Decidim.traceability).to receive(:perform_action!).with(
+                "invite",
+                user,
+                current_user,
+                extra: {
+                  invited_user_role: "participant",
+                  invited_user_id: user.id
+                }
+              )
+              subject.track(type, "email@example.com", user)
+            end
+          end
+
+          context "and the provided type does not exist" do
+            let(:type) { :fake }
+
+            it "raises due to NilClass" do
+              expect { subject.track(type, "email@example.com", user) }.to raise_error(NoMethodError)
+            end
+          end
+        end
+
+        context "when a user is not passed" do
+          context "and the provided type exists" do
+            let(:type) { :registered }
+
+            it "adds the error event" do
+              subject.track(type, "email@example.com")
+              expect(subject.errors[type]).to contain_exactly("email@example.com")
+            end
+          end
+
+          context "and the provided type does not exist" do
+            let(:type) { :fake }
+
+            it "raises due to NilClass" do
+              expect { subject.track(type, "email@example.com") }.to raise_error(NoMethodError)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/instrumenter_spec.rb
+++ b/spec/lib/decidim/direct_verifications/instrumenter_spec.rb
@@ -13,7 +13,7 @@ module Decidim
         context "when the email does not exist" do
           it "adds the email" do
             subject.add_error(type, "email@example.com")
-            expect(subject.errors[type]).to contain_exactly("email@example.com")
+            expect(subject.errors_count(type)).to eq(1)
           end
         end
 
@@ -22,7 +22,7 @@ module Decidim
 
           it "does not duplicate the email" do
             subject.add_error(type, "email@example.com")
-            expect(subject.errors[type]).to contain_exactly("email@example.com")
+            expect(subject.errors_count(type)).to eq(1)
           end
         end
       end
@@ -31,7 +31,7 @@ module Decidim
         context "when the email does not exist" do
           it "adds the email" do
             subject.add_processed(type, "email@example.com")
-            expect(subject.processed[type]).to contain_exactly("email@example.com")
+            expect(subject.processed_count(type)).to eq(1)
           end
         end
 
@@ -40,7 +40,7 @@ module Decidim
 
           it "does not duplicate the email" do
             subject.add_processed(type, "email@example.com")
-            expect(subject.processed[type]).to contain_exactly("email@example.com")
+            expect(subject.processed_count(type)).to eq(1)
           end
         end
       end
@@ -84,7 +84,7 @@ module Decidim
 
             it "adds the process event" do
               subject.track(type, "email@example.com", user)
-              expect(subject.processed[type]).to contain_exactly("email@example.com")
+              expect(subject.processed_count(type)).to eq(1)
             end
 
             it "logs the action" do
@@ -116,7 +116,7 @@ module Decidim
 
             it "adds the error event" do
               subject.track(type, "email@example.com")
-              expect(subject.errors[type]).to contain_exactly("email@example.com")
+              expect(subject.errors_count(type)).to eq(1)
             end
           end
 

--- a/spec/lib/decidim/direct_verifications/register_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/register_user_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:user) { build(:user) }
       let(:organization) { build(:organization) }
-      let(:instrumenter) { instance_double(UserProcessor, track: true) }
+      let(:instrumenter) { instance_double(Instrumenter, track: true) }
 
       let(:email) { "em@il.com" }
       let(:name) { "Joni" }

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   module DirectVerifications
     describe RevokeUser do
-      subject { described_class.new(email, organization, instrumenter) }
+      subject { described_class.new(email, organization, instrumenter, "direct_verifications") }
 
       let(:user) { create(:user, organization: organization) }
       let(:email) { user.email }
@@ -81,11 +81,11 @@ module Decidim
             allow(authorization).to receive(:destroy!).and_raise(ActiveRecord::ActiveRecordError)
             allow(Authorization)
               .to receive(:find_by)
-              .with(user: user, name: :direct_verifications)
+              .with(user: user, name: "direct_verifications")
               .and_return(authorization)
           end
 
-          it "lets lower-level exceptions to pass through" do
+          it "lets lower-level exceptions pass through" do
             expect { subject.call }.to raise_error(ActiveRecord::ActiveRecordError)
           end
         end

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       describe "#call" do
         let(:organization) { build(:organization) }
-        let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+        let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
         context "when revoking existing users" do
           let(:user) { create(:user, organization: organization) }

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe RevokeUser do
+      subject { described_class.new(email, organization, instrumenter) }
+
+      describe "#call" do
+        let(:organization) { build(:organization) }
+        let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+
+        context "when revoking existing users" do
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+
+          before { create(:authorization, :granted, user: user, name: :direct_verifications) }
+
+          it "tracks the operation" do
+            subject.call
+            expect(instrumenter).to have_received(:add_processed).with(:revoked, email)
+          end
+
+          it "revokes the user authorization" do
+            expect(Verification::DestroyUserAuthorization).to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when revoking non-existing users" do
+          let(:email) { "em@mail.com" }
+
+          it "tracks the error" do
+            subject.call
+            expect(instrumenter).to have_received(:add_error).with(:revoked, email)
+          end
+
+          it "does not revoke the authorization" do
+            expect(Verification::DestroyUserAuthorization).not_to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when the authorization does not exist" do
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+
+          it "does not track the operation" do
+            subject.call
+            expect(instrumenter).not_to have_received(:add_processed)
+            expect(instrumenter).not_to have_received(:add_error)
+          end
+
+          it "does not revoke the authorization" do
+            expect(Verification::DestroyUserAuthorization).not_to receive(:call)
+            subject.call
+          end
+        end
+
+        context "when the authorization is not granted" do
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+
+          before { create(:authorization, :pending, user: user, name: :direct_verifications) }
+
+          it "does not track the operation" do
+            subject.call
+            expect(instrumenter).not_to have_received(:add_processed)
+            expect(instrumenter).not_to have_received(:add_error)
+          end
+
+          it "does not revoke the authorization" do
+            expect(Verification::DestroyUserAuthorization).not_to receive(:call)
+            subject.call
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -75,6 +75,24 @@ module Decidim
             subject.call
           end
         end
+
+        context "when the authorization fails to be destroyed" do
+          let(:user) { create(:user, organization: organization) }
+          let(:email) { user.email }
+          let(:authorization) { create(:authorization, :granted, user: user, name: :direct_verifications) }
+
+          before do
+            allow(authorization).to receive(:destroy!).and_raise(ActiveRecord::ActiveRecordError)
+            allow(Authorization)
+              .to receive(:find_by)
+              .with(user: user, name: :direct_verifications)
+              .and_return(authorization)
+          end
+
+          it "lets lower-level exceptions to pass through" do
+            expect { subject.call }.to raise_error(ActiveRecord::ActiveRecordError)
+          end
+        end
       end
     end
   end

--- a/spec/lib/decidim/direct_verifications/user_processor_spec.rb
+++ b/spec/lib/decidim/direct_verifications/user_processor_spec.rb
@@ -163,36 +163,6 @@ module Decidim
           expect(subject.errors[:revoked].count).to eq(1)
         end
       end
-
-      context "when the authorization does not exist" do
-        before do
-          create(:user, email: "em@il.com", organization: organization)
-          subject.emails = ["em@il.com"]
-        end
-
-        it "has no errors" do
-          subject.revoke_users
-
-          expect(subject.processed[:revoked].count).to eq(0)
-          expect(subject.errors[:revoked].count).to eq(0)
-        end
-      end
-
-      context "when the authorization is not granted" do
-        let(:user) { create(:user, email: "em@il.com", organization: organization) }
-
-        before do
-          subject.emails = ["em@il.com"]
-          create(:authorization, :pending, user: user, name: :direct_verifications)
-        end
-
-        it "has no errors" do
-          subject.revoke_users
-
-          expect(subject.processed[:revoked].count).to eq(0)
-          expect(subject.errors[:revoked].count).to eq(0)
-        end
-      end
     end
   end
 end

--- a/spec/lib/decidim/direct_verifications/user_processor_spec.rb
+++ b/spec/lib/decidim/direct_verifications/user_processor_spec.rb
@@ -41,8 +41,8 @@ module Decidim
           end
 
           it "has no errors" do
-            expect(instrumenter.processed[:registered].count).to eq(2)
-            expect(instrumenter.errors[:registered].count).to eq(0)
+            expect(instrumenter.processed_count(:registered)).to eq(2)
+            expect(instrumenter.errors_count(:registered)).to eq(0)
           end
         end
 
@@ -53,8 +53,8 @@ module Decidim
           end
 
           it "has no errors" do
-            expect(instrumenter.processed[:registered].count).to eq(1)
-            expect(instrumenter.errors[:registered].count).to eq(0)
+            expect(instrumenter.processed_count(:registered)).to eq(1)
+            expect(instrumenter.errors_count(:registered)).to eq(0)
           end
         end
       end
@@ -68,8 +68,8 @@ module Decidim
           it "has no errors" do
             subject.authorize_users
 
-            expect(instrumenter.processed[:authorized].count).to eq(1)
-            expect(instrumenter.errors[:authorized].count).to eq(0)
+            expect(instrumenter.processed_count(:authorized)).to eq(1)
+            expect(instrumenter.errors_count(:authorized)).to eq(0)
           end
         end
 
@@ -93,8 +93,8 @@ module Decidim
           it "has no errors" do
             subject.authorize_users
 
-            expect(instrumenter.processed[:authorized].count).to eq(1)
-            expect(instrumenter.errors[:authorized].count).to eq(0)
+            expect(instrumenter.processed_count(:authorized)).to eq(1)
+            expect(instrumenter.errors_count(:authorized)).to eq(0)
           end
         end
 
@@ -122,8 +122,8 @@ module Decidim
         it "has no errors" do
           subject.revoke_users
 
-          expect(instrumenter.processed[:revoked].count).to eq(1)
-          expect(instrumenter.errors[:revoked].count).to eq(0)
+          expect(instrumenter.processed_count(:revoked)).to eq(1)
+          expect(instrumenter.errors_count(:revoked)).to eq(0)
         end
       end
 
@@ -136,8 +136,8 @@ module Decidim
         it "has errors" do
           subject.revoke_users
 
-          expect(instrumenter.processed[:revoked].count).to eq(0)
-          expect(instrumenter.errors[:revoked].count).to eq(1)
+          expect(instrumenter.processed_count(:revoked)).to eq(0)
+          expect(instrumenter.errors_count(:revoked)).to eq(1)
         end
       end
     end

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -8,10 +8,11 @@ module Decidim
       let(:user) { build(:user) }
 
       describe "#finished_processing" do
-        subject(:mail) { described_class.finished_processing(user, instrumenter, type) }
+        subject(:mail) { described_class.finished_processing(user, instrumenter, type, handler) }
 
         let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 1, errors_count: 0) }
         let(:type) { :registered }
+        let(:handler) { :direct_verifications }
 
         it "sends the email to the passed user" do
           expect(mail.to).to eq([user.email])

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -7,26 +7,65 @@ module Decidim
     describe ImportMailer, type: :mailer do
       let(:user) { build(:user) }
 
-      describe "#successful_import" do
-        subject(:mail) { described_class.successful_import(user) }
+      describe "#finished_registration" do
+        subject(:mail) { described_class.finished_registration(user, instrumenter) }
 
-        it "sends the email to the passed user" do
-          expect(mail.to).to eq([user.email])
+        context "when the import had no errors" do
+          let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 1, errors_count: 0) }
+
+          it "sends the email to the passed user" do
+            expect(mail.to).to eq([user.email])
+          end
+
+          it "renders the subject" do
+            expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
+          end
+
+          it "localizes the subject" do
+            user.locale = "ca"
+            expect(I18n).to receive(:with_locale).with("ca")
+
+            mail.body
+          end
+
+          it "renders the body" do
+            expect(mail.body.encoded).to include(
+              "1 users have been successfully registered (1 detected, 0 errors)"
+            )
+          end
+
+          it "sets the organization" do
+            expect(mail.body.encoded).to include(user.organization.name)
+          end
         end
 
-        it "localizes the subject" do
-          user.locale = "ca"
-          expect(I18n).to receive(:with_locale).with("ca")
+        context "when the import had errors" do
+          let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 0, errors_count: 1) }
 
-          mail.body
-        end
+          it "sends the email to the passed user" do
+            expect(mail.to).to eq([user.email])
+          end
 
-        it "renders the body" do
-          expect(mail.body.encoded).to include("Register successful")
-        end
+          it "renders the subject" do
+            expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
+          end
 
-        it "sets the organization" do
-          expect(mail.body.encoded).to include(user.organization.name)
+          it "localizes the subject" do
+            user.locale = "ca"
+            expect(I18n).to receive(:with_locale).with("ca")
+
+            mail.body
+          end
+
+          it "renders the body" do
+            expect(mail.body.encoded).to include(
+              "0 users have been successfully registered (1 detected, 1 errors)"
+            )
+          end
+
+          it "sets the organization" do
+            expect(mail.body.encoded).to include(user.organization.name)
+          end
         end
       end
     end

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -5,10 +5,10 @@ require "spec_helper"
 module Decidim
   module DirectVerifications
     describe ImportMailer, type: :mailer do
+      let(:user) { build(:user) }
+
       describe "#successful_import" do
         subject(:mail) { described_class.successful_import(user) }
-
-        let(:user) { build(:user) }
 
         it "sends the email to the passed user" do
           expect(mail.to).to eq([user.email])
@@ -16,7 +16,6 @@ module Decidim
 
         it "localizes the subject" do
           user.locale = "ca"
-          user.save!
           expect(I18n).to receive(:with_locale).with("ca")
 
           mail.body

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe ImportMailer, type: :mailer do
+      describe "#successful_import" do
+        subject(:mail) { described_class.successful_import(user) }
+
+        let(:user) { build(:user) }
+
+        it "sends the email to the passed user" do
+          expect(mail.to).to eq([user.email])
+        end
+
+        it "localizes the subject" do
+          user.locale = "ca"
+          user.save!
+          expect(I18n).to receive(:with_locale).with("ca")
+
+          mail.body
+        end
+
+        it "renders the body" do
+          expect(mail.body.encoded).to include("Register successful")
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -24,6 +24,10 @@ module Decidim
         it "renders the body" do
           expect(mail.body.encoded).to include("Register successful")
         end
+
+        it "sets the organization" do
+          expect(mail.body.encoded).to include(user.organization.name)
+        end
       end
     end
   end

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -7,64 +7,72 @@ module Decidim
     describe ImportMailer, type: :mailer do
       let(:user) { build(:user) }
 
-      describe "#finished_registration" do
-        subject(:mail) { described_class.finished_registration(user, instrumenter) }
+      describe "#finished_processing" do
+        subject(:mail) { described_class.finished_processing(user, instrumenter, type) }
 
-        context "when the import had no errors" do
-          let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 1, errors_count: 0) }
+        let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 1, errors_count: 0) }
+        let(:type) { :registered }
 
-          it "sends the email to the passed user" do
-            expect(mail.to).to eq([user.email])
+        it "sends the email to the passed user" do
+          expect(mail.to).to eq([user.email])
+        end
+
+        it "renders the subject" do
+          expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
+        end
+
+        it "localizes the subject" do
+          user.locale = "ca"
+          expect(I18n).to receive(:with_locale).with("ca")
+
+          mail.body
+        end
+
+        it "sets the organization" do
+          expect(mail.body.encoded).to include(user.organization.name)
+        end
+
+        context "when the type is :registered" do
+          let(:type) { :registered }
+
+          context "when the import had no errors" do
+            it "shows the number of errors" do
+              expect(mail.body.encoded).to include(
+                "1 users have been successfully registered (1 detected, 0 errors)"
+              )
+            end
           end
 
-          it "renders the subject" do
-            expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
-          end
+          context "when the import had errors" do
+            let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 0, errors_count: 1) }
 
-          it "localizes the subject" do
-            user.locale = "ca"
-            expect(I18n).to receive(:with_locale).with("ca")
-
-            mail.body
-          end
-
-          it "renders the body" do
-            expect(mail.body.encoded).to include(
-              "1 users have been successfully registered (1 detected, 0 errors)"
-            )
-          end
-
-          it "sets the organization" do
-            expect(mail.body.encoded).to include(user.organization.name)
+            it "shows the number of errors" do
+              expect(mail.body.encoded).to include(
+                "0 users have been successfully registered (1 detected, 1 errors)"
+              )
+            end
           end
         end
 
-        context "when the import had errors" do
-          let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 0, errors_count: 1) }
+        context "when the type is :revoked" do
+          let(:type) { :revoked }
 
-          it "sends the email to the passed user" do
-            expect(mail.to).to eq([user.email])
+          context "when the import had no errors" do
+            it "shows the number of errors" do
+              expect(mail.body.encoded).to include(
+                "Verification from 1 users have been revoked using [direct_verifications] (1 detected, 0 errors)"
+              )
+            end
           end
 
-          it "renders the subject" do
-            expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
-          end
+          context "when the import had errors" do
+            let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 0, errors_count: 1) }
 
-          it "localizes the subject" do
-            user.locale = "ca"
-            expect(I18n).to receive(:with_locale).with("ca")
-
-            mail.body
-          end
-
-          it "renders the body" do
-            expect(mail.body.encoded).to include(
-              "0 users have been successfully registered (1 detected, 1 errors)"
-            )
-          end
-
-          it "sets the organization" do
-            expect(mail.body.encoded).to include(user.organization.name)
+            it "shows the number of errors" do
+              expect(mail.body.encoded).to include(
+                "Verification from 0 users have been revoked using [direct_verifications] (1 detected, 1 errors)"
+              )
+            end
           end
         end
       end

--- a/spec/mailers/previews/import_mailer_preview.rb
+++ b/spec/mailers/previews/import_mailer_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Decidim
+  class ImportMailerPreview < ActionMailer::Preview
+    def successful_import
+      DirectVerifications::ImportMailer.successful_import(User.first)
+    end
+  end
+end

--- a/spec/mailers/previews/import_mailer_preview.rb
+++ b/spec/mailers/previews/import_mailer_preview.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 module Decidim
-  class ImportMailerPreview < ActionMailer::Preview
-    def successful_import
-      DirectVerifications::ImportMailer.successful_import(User.first)
+  module DirectVerifications
+    class ImportMailerPreview < ActionMailer::Preview
+      def finished_registration
+        user = User.first
+
+        instrumenter = Instrumenter.new(user)
+        instrumenter.add_processed(:registered, "email@example.com")
+
+        ImportMailer.finished_registration(user, instrumenter)
+      end
     end
   end
 end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -14,15 +14,7 @@ describe "Admin imports users", type: :system do
   end
 
   context "when visiting the imports page" do
-    let(:filename) { "fixture.csv" }
-    let!(:fixture_file) do
-      CSV.open(filename, "wb") do |csv|
-        csv << %w(Name Email Type)
-        csv << %w(Brandy brandy@example.com consumer)
-      end
-    end
-
-    after { File.delete(filename) }
+    let(:filename) { file_fixture("users.csv") }
 
     it "enables uploading a CSV file" do
       attach_file("CSV file with users data", filename)

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -34,6 +34,8 @@ describe "Admin imports users", type: :system do
       expect(page).to have_admin_callout("successfully")
       expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
       expect(Decidim::User.last.email).to eq("brandy@example.com")
+      expect(ActionMailer::Base.deliveries.last.subject)
+        .to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject"))
     end
   end
 end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin imports users", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+
+    visit decidim_admin_direct_verifications.new_import_path
+  end
+
+  context "when visiting the imports page" do
+    let(:filename) { "fixture.csv" }
+    let!(:fixture_file) do
+      CSV.open(filename, "wb") do |csv|
+        csv << %w(Name Email Type)
+        csv << %w(Brandy brandy@example.com consumer)
+      end
+    end
+
+    after { File.delete(filename) }
+
+    it "enables uploading a CSV file" do
+      attach_file("CSV file with users data", filename)
+
+      perform_enqueued_jobs do
+        click_button("Upload file")
+      end
+
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+      expect(Decidim::User.last.email).to eq("brandy@example.com")
+    end
+  end
+end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -69,12 +69,21 @@ describe "Admin imports users", type: :system do
       expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
 
       click_link I18n.t("index.authorizations", scope: "decidim.direct_verifications.verification.admin")
-      expect(page).to have_content("Brandy")
+      expect(page).not_to have_content("Brandy") # In the authorizations page we only show those with :direct_verifications
 
       expect(ActionMailer::Base.deliveries.first.to).to contain_exactly("brandy@example.com")
       expect(ActionMailer::Base.deliveries.first.subject).to eq("Invitation instructions")
 
-      expect(ActionMailer::Base.deliveries.last.body.encoded).to include(
+      expect(ActionMailer::Base.deliveries.second.body.encoded).to include(
+        I18n.t(
+          "#{i18n_scope}.imports.mailer.registered",
+          count: 1,
+          successful: 1,
+          errors: 0
+        )
+      )
+
+      expect(ActionMailer::Base.deliveries.third.body.encoded).to include(
         I18n.t(
           "#{i18n_scope}.imports.mailer.authorized",
           handler: :other_verification_method,

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -13,6 +13,12 @@ describe "Admin imports users", type: :system do
     switch_to_host(organization.host)
     login_as user, scope: :user
 
+    organization.available_authorizations = %w(direct_verifications other_verification_method)
+    organization.save!
+    Decidim::DirectVerifications.configure do |config|
+      config.manage_workflows = %w(other_verification_method)
+    end
+
     visit decidim_admin_direct_verifications.new_import_path
   end
 
@@ -87,8 +93,11 @@ describe "Admin imports users", type: :system do
 
     it "revokes users through a CSV file" do
       attach_file("CSV file with users data", filename)
-
       choose(I18n.t("#{i18n_scope}.new.revoke"))
+      select(
+        "translation missing: en.decidim.authorization_handlers.other_verification_method.name",
+        from: "Verification method"
+      )
 
       perform_enqueued_jobs do
         click_button("Upload file")

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -28,7 +28,7 @@ describe "Admin imports users", type: :system do
           click_button("Upload file")
         end
 
-        expect(page).to have_admin_callout("successfully")
+        expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
         expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
 
         expect(Decidim::User.last.email).to eq("brandy@example.com")

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -6,6 +6,9 @@ describe "Admin imports users", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization: organization) }
 
+  let(:i18n_scope) { "decidim.direct_verifications.verification.admin" }
+  let(:last_email_delivery) { ActionMailer::Base.deliveries.last }
+
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
@@ -19,7 +22,7 @@ describe "Admin imports users", type: :system do
     context "when authorizing users" do
       it "registers users through a CSV file" do
         attach_file("CSV file with users data", filename)
-        choose(I18n.t("decidim.direct_verifications.verification.admin.new.authorize"))
+        choose(I18n.t("#{i18n_scope}.new.authorize"))
 
         perform_enqueued_jobs do
           click_button("Upload file")
@@ -28,8 +31,11 @@ describe "Admin imports users", type: :system do
         expect(page).to have_admin_callout("successfully")
         expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
         expect(Decidim::User.last.email).to eq("brandy@example.com")
-        expect(ActionMailer::Base.deliveries.last.subject)
-          .to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject"))
+
+        expect(last_email_delivery.subject).to eq(I18n.t("#{i18n_scope}.imports.mailer.subject"))
+        expect(last_email_delivery.body.encoded).to include(
+          I18n.t("#{i18n_scope}.direct_verifications.create.registered", count: 1, registered: 1, errors: 0)
+        )
       end
     end
   end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -88,7 +88,7 @@ describe "Admin imports users", type: :system do
     end
 
     before do
-      create(:authorization, :granted, user: user_to_revoke, name: :direct_verifications)
+      create(:authorization, :granted, user: user_to_revoke, name: :other_verification_method)
     end
 
     it "revokes users through a CSV file" do
@@ -112,7 +112,7 @@ describe "Admin imports users", type: :system do
       expect(ActionMailer::Base.deliveries.last.body.encoded).to include(
         I18n.t(
           "#{i18n_scope}.imports.mailer.revoked",
-          handler: :direct_verifications,
+          handler: :other_verification_method,
           count: 1,
           successful: 1,
           errors: 0

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -52,8 +52,8 @@ describe "Admin imports users", type: :system do
       expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
       expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
 
-      user = Decidim::User.last
-      expect(Decidim::Authorization.find_by(decidim_user_id: user.id)).not_to be_nil
+      click_link I18n.t("index.authorizations", scope: "decidim.direct_verifications.verification.admin")
+      expect(page).to have_content("Brandy")
 
       expect(ActionMailer::Base.deliveries.first.to).to contain_exactly("brandy@example.com")
       expect(ActionMailer::Base.deliveries.first.subject).to eq("Invitation instructions")
@@ -91,7 +91,8 @@ describe "Admin imports users", type: :system do
       expect(page).to have_admin_callout("successfully")
       expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
 
-      expect(Decidim::Authorization.find_by(decidim_user_id: user_to_revoke.id)).to be_nil
+      click_link I18n.t("index.authorizations", scope: "decidim.direct_verifications.verification.admin")
+      expect(page).not_to have_content("Brandy")
 
       expect(ActionMailer::Base.deliveries.last.body.encoded).to include(
         I18n.t(

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -30,11 +30,45 @@ describe "Admin imports users", type: :system do
 
         expect(page).to have_admin_callout("successfully")
         expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+
         expect(Decidim::User.last.email).to eq("brandy@example.com")
 
-        expect(last_email_delivery.subject).to eq(I18n.t("#{i18n_scope}.imports.mailer.subject"))
         expect(last_email_delivery.body.encoded).to include(
-          I18n.t("#{i18n_scope}.direct_verifications.create.registered", count: 1, registered: 1, errors: 0)
+          I18n.t("#{i18n_scope}.imports.mailer.registered", count: 1, successful: 1, errors: 0)
+        )
+      end
+    end
+
+    context "when revoking users" do
+      let(:user_to_revoke) do
+        create(:user, name: "Brandy", email: "brandy@example.com", organization: organization)
+      end
+
+      before do
+        create(:authorization, :granted, user: user_to_revoke, name: :direct_verifications)
+      end
+
+      it "registers users through a CSV file" do
+        attach_file("CSV file with users data", filename)
+        choose(I18n.t("#{i18n_scope}.new.revoke"))
+
+        perform_enqueued_jobs do
+          click_button("Upload file")
+        end
+
+        expect(page).to have_admin_callout("successfully")
+        expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+
+        expect(Decidim::Authorization.find_by(decidim_user_id: user_to_revoke.id)).to be_nil
+
+        expect(last_email_delivery.body.encoded).to include(
+          I18n.t(
+            "#{i18n_scope}.imports.mailer.revoked",
+            handler: :direct_verifications,
+            count: 1,
+            successful: 1,
+            errors: 0
+          )
         )
       end
     end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -56,6 +56,10 @@ describe "Admin imports users", type: :system do
 
       check(I18n.t("#{i18n_scope}.new.register"))
       choose(I18n.t("#{i18n_scope}.new.authorize"))
+      select(
+        "translation missing: en.decidim.authorization_handlers.other_verification_method.name",
+        from: "Verification method"
+      )
 
       perform_enqueued_jobs do
         click_button("Upload file")
@@ -73,7 +77,7 @@ describe "Admin imports users", type: :system do
       expect(ActionMailer::Base.deliveries.last.body.encoded).to include(
         I18n.t(
           "#{i18n_scope}.imports.mailer.authorized",
-          handler: :direct_verifications,
+          handler: :other_verification_method,
           count: 1,
           successful: 1,
           errors: 0

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -16,18 +16,21 @@ describe "Admin imports users", type: :system do
   context "when visiting the imports page" do
     let(:filename) { file_fixture("users.csv") }
 
-    it "enables uploading a CSV file" do
-      attach_file("CSV file with users data", filename)
+    context "when authorizing users" do
+      it "registers users through a CSV file" do
+        attach_file("CSV file with users data", filename)
+        choose(I18n.t("decidim.direct_verifications.verification.admin.new.authorize"))
 
-      perform_enqueued_jobs do
-        click_button("Upload file")
+        perform_enqueued_jobs do
+          click_button("Upload file")
+        end
+
+        expect(page).to have_admin_callout("successfully")
+        expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+        expect(Decidim::User.last.email).to eq("brandy@example.com")
+        expect(ActionMailer::Base.deliveries.last.subject)
+          .to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject"))
       end
-
-      expect(page).to have_admin_callout("successfully")
-      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
-      expect(Decidim::User.last.email).to eq("brandy@example.com")
-      expect(ActionMailer::Base.deliveries.last.subject)
-        .to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject"))
     end
   end
 end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -16,6 +16,12 @@ describe "Admin imports users", type: :system do
     visit decidim_admin_direct_verifications.new_import_path
   end
 
+  it "can be accessed from direct_verifications_path" do
+    visit decidim_admin_direct_verifications.direct_verifications_path
+    click_link "import a CSV"
+    expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+  end
+
   context "when registering users" do
     it "registers users through a CSV file" do
       attach_file("CSV file with users data", filename)

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -9,6 +9,8 @@ describe "Admin imports users", type: :system do
   let(:i18n_scope) { "decidim.direct_verifications.verification.admin" }
   let(:last_email_delivery) { ActionMailer::Base.deliveries.last }
 
+  let(:filename) { file_fixture("users.csv") }
+
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
@@ -16,61 +18,89 @@ describe "Admin imports users", type: :system do
     visit decidim_admin_direct_verifications.new_import_path
   end
 
-  context "when visiting the imports page" do
-    let(:filename) { file_fixture("users.csv") }
+  context "when registering users" do
+    it "registers users through a CSV file" do
+      attach_file("CSV file with users data", filename)
 
-    context "when authorizing users" do
-      it "registers users through a CSV file" do
-        attach_file("CSV file with users data", filename)
-        choose(I18n.t("#{i18n_scope}.new.authorize"))
+      check(I18n.t("#{i18n_scope}.new.register"))
 
-        perform_enqueued_jobs do
-          click_button("Upload file")
-        end
-
-        expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
-        expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
-
-        expect(Decidim::User.last.email).to eq("brandy@example.com")
-
-        expect(last_email_delivery.body.encoded).to include(
-          I18n.t("#{i18n_scope}.imports.mailer.registered", count: 1, successful: 1, errors: 0)
-        )
+      perform_enqueued_jobs do
+        click_button("Upload file")
       end
+
+      expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
+      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+
+      expect(Decidim::User.last.email).to eq("brandy@example.com")
+
+      expect(last_email_delivery.body.encoded).to include(
+        I18n.t("#{i18n_scope}.imports.mailer.registered", count: 1, successful: 1, errors: 0)
+      )
+    end
+  end
+
+  context "when registering and authorizing users" do
+    it "registers and authorizes users through a CSV file" do
+      attach_file("CSV file with users data", filename)
+
+      check(I18n.t("#{i18n_scope}.new.register"))
+      choose(I18n.t("#{i18n_scope}.new.authorize"))
+
+      perform_enqueued_jobs do
+        click_button("Upload file")
+      end
+
+      expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
+      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+
+      user = Decidim::User.last
+      expect(user.email).to eq("brandy@example.com")
+      expect(Decidim::Authorization.find_by(decidim_user_id: user.id)).not_to be_nil
+
+      expect(last_email_delivery.body.encoded).to include(
+        I18n.t(
+          "#{i18n_scope}.imports.mailer.authorized",
+          handler: :direct_verifications,
+          count: 1,
+          successful: 1,
+          errors: 0
+        )
+      )
+    end
+  end
+
+  context "when revoking users" do
+    let(:user_to_revoke) do
+      create(:user, name: "Brandy", email: "brandy@example.com", organization: organization)
     end
 
-    context "when revoking users" do
-      let(:user_to_revoke) do
-        create(:user, name: "Brandy", email: "brandy@example.com", organization: organization)
+    before do
+      create(:authorization, :granted, user: user_to_revoke, name: :direct_verifications)
+    end
+
+    it "registers users through a CSV file" do
+      attach_file("CSV file with users data", filename)
+
+      choose(I18n.t("#{i18n_scope}.new.revoke"))
+
+      perform_enqueued_jobs do
+        click_button("Upload file")
       end
 
-      before do
-        create(:authorization, :granted, user: user_to_revoke, name: :direct_verifications)
-      end
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
 
-      it "registers users through a CSV file" do
-        attach_file("CSV file with users data", filename)
-        choose(I18n.t("#{i18n_scope}.new.revoke"))
+      expect(Decidim::Authorization.find_by(decidim_user_id: user_to_revoke.id)).to be_nil
 
-        perform_enqueued_jobs do
-          click_button("Upload file")
-        end
-
-        expect(page).to have_admin_callout("successfully")
-        expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
-
-        expect(Decidim::Authorization.find_by(decidim_user_id: user_to_revoke.id)).to be_nil
-
-        expect(last_email_delivery.body.encoded).to include(
-          I18n.t(
-            "#{i18n_scope}.imports.mailer.revoked",
-            handler: :direct_verifications,
-            count: 1,
-            successful: 1,
-            errors: 0
-          )
+      expect(last_email_delivery.body.encoded).to include(
+        I18n.t(
+          "#{i18n_scope}.imports.mailer.revoked",
+          handler: :direct_verifications,
+          count: 1,
+          successful: 1,
+          errors: 0
         )
-      end
+      )
     end
   end
 end

--- a/spec/system/decidim/direct_verifications/admin/direct_verifications_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/direct_verifications_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin creates direct verifications", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  let(:i18n_scope) { "decidim.direct_verifications.verification.admin.direct_verifications" }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+
+    visit decidim_admin_direct_verifications.direct_verifications_path
+  end
+
+  around do |example|
+    original_processor = Rails.configuration.direct_verifications_parser
+    Rails.configuration.direct_verifications_parser = :metadata
+    example.run
+    Rails.configuration.direct_verifications_parser = original_processor
+  end
+
+  context "when registering users" do
+    context "and no header is provided" do
+      it "shows an error message" do
+        fill_in "Emails list", with: "brandy@example.com,,consumer"
+        check "register"
+        choose "authorize_in"
+
+        click_button "Send and process the list"
+
+        expect(page).to have_content(I18n.t("#{i18n_scope}.create.missing_header"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Finally, this closes #3 . I know, this is too big to be thoroughly reviewed. It includes all the iterative PRs we opened against our fork so, alternatively, you can review each of them alternatively https://github.com/coopdevs/decidim-verifications-direct_verifications/milestone/1?closed=1. Just let me know if you prefer any other approach.

This has been live for a couple of weeks already, tested with 100-rows file and provided to be stable.

## Changes

It introduces the following logical changes:

* Processes registrations, authorizations and revocations separately, away from `UserProcessor` so they can be called as needed.
* Extracts the responsibility of tracking import success/errors onto a new `Instrumenter` class.
* Enables performing these three different actions asynchronously from a new page. This includes new: route, controller, view, command, form, job, mailer, and mail view.
* To keep things backward compatible, it allows the user to choose whether they want to import through CSV, navigating to the page above.
* Better UX warning users about missing header row. See https://github.com/coopdevs/decidim-verifications-direct_verifications/pull/25
* Restored the ability to use any verification method to authorize users, which we dropped along the way. See: https://github.com/coopdevs/decidim-verifications-direct_verifications/pull/27

## Further considerations

Some things to take into account:

1. All emails (each CSV row) are processed in a single job, which can potentially block the background worker for quite some time when importing large files, and increases its memory consumption considerably. Splitting into multiple jobs would be substantially more complex.
2. when registering and authorizing at the same time, we register them first with the `RegisterUsersJob` and then, we make them go through `AuthorizeUsersJob`. This leads to two separate email notifications.
3. The uploaded CSV file is read at request time and its contents passed to the jobs, which may be troublesome in some edge cases. I found no evidence of any length limit on ActiveJob arguments but it could be the case. Likewise, this will increase the memory usage of the app server. A potential solution is to upload the file straight to object storage and read it from the background worker node.

## UX/UI

Nothing especially new. I reused as much as I could.

![Peek 2021-06-03 12-12](https://user-images.githubusercontent.com/762088/120628483-07691400-c465-11eb-9bd3-b4dd93a48d07.gif)

