### PR TITLE
Fix bug in name parser

### DIFF
--- a/lib/decidim/direct_verifications/parsers/name_parser.rb
+++ b/lib/decidim/direct_verifications/parsers/name_parser.rb
@@ -18,7 +18,7 @@ module Decidim
         def parse_data(email, line, _header)
           name = parse_name(email, line)
           name = strip_non_alpha_chars(name)
-          name.presence || fallback_name(email)
+          { name: name.presence || fallback_name(email) }
         end
 
         private


### PR DESCRIPTION
Error in tests:

```
Webpacker can't find decidim_email.css in /home/vera/Platoniq/Decidim/modules/direct-verifications/spec/decidim_dummy_app/public/packs-test/manifest.json
```