### PR TITLE
chore: improve direct invite by allowing html in someone_invited_you

### DIFF
--- a/app/views/devise/mailer/direct_invite.html.erb
+++ b/app/views/devise/mailer/direct_invite.html.erb
@@ -1,7 +1,7 @@
 <p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.name) %></p>
 
 <p>
-  <%= t("devise.mailer.invitation_instructions.someone_invited_you", application: @resource.organization.name) %>
+  <%= t("devise.mailer.invitation_instructions.someone_invited_you", application: @resource.organization.name).html_safe %>
 </p>
 
 <p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim.root_path, host: @resource.organization.host) %></p>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,11 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url).html_safe %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>


### PR DESCRIPTION
The direct invitation email is the entry for some collective. The invitation must be well framed and easly readable. 
As it is now, we can't set an introduction in the email in html. This is making difficult a proper well framed invitation.

This PR is to change the direct_invite mail to accept html, using the `.html_safe` erb filter. 

Thanks